### PR TITLE
skills/task-subagent-delegation: prohibit recursive subagent spawn

### DIFF
--- a/skills/task-subagent-delegation/SKILL.md
+++ b/skills/task-subagent-delegation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-subagent-delegation
-description: Invoke when delegating implementation or operations to a subagent; defines what to convey, what parent retains, and mode-dependent execution scope.
+description: Invoke when delegating implementation, operations, or a bounded read-only investigation (audit / consistency check / grep-and-report) to a subagent; defines what to convey, what parent retains, and mode-dependent execution scope.
 layer: L3-task
 ---
 
@@ -105,6 +105,26 @@ Detection signs:
 - Subagent reports "pre-existing em-dash found in previously-merged artifact" — the propagation already happened.
 
 </delegation-prompt-hygiene-ascii-only-example-text>
+
+<bounded-delegation-prohibit-recursive-subagent-spawn>
+
+## Bounded delegation: prohibit recursive subagent spawn
+
+A subagent with Agent tool access (`Tools: *`, typically `general-purpose`) defaults to the same fan-out instinct the parent has: when its assigned task looks like it has multiple independent sub-checks, it may spawn its own nested Agent-tool children rather than executing directly. Absent an explicit prohibition, this can cascade at every level — each hop adds real API cost with no visible warning until the rate limit wall is hit, and the top-level report ends up as coordinator meta-commentary ("waiting for background agent") instead of actual findings.
+
+How to apply:
+- When delegating a bounded read-only investigation (audit / consistency check / grep-and-report) to a subagent, explicitly state in the prompt: "Do this yourself directly using Read/Grep/Bash — do not spawn further subagents via the Agent tool for this task."
+- If a subagent's task has 2-3 independent sub-checks that seem parallelizable, prefer sequencing them directly inside one subagent's own tool calls over letting it decide to spawn children.
+- Reserve subagent-of-subagent delegation for genuinely large-scale parallel work where the fan-out is deliberate and bounded (e.g. `skills/evolution-parallel-agent-eval` N=3 evaluator pattern — a controlled, known-width fan-out is exempt from this prohibition).
+
+This is a tool-authority bound (which tools the subagent may use), not a conveyed step-by-step procedure — it does not conflict with the top-level Rules section's "do not convey: step-by-step procedure" constraint, same reconciliation as `mode-specific-delegation-injection` above.
+
+Detection signs:
+- About to write a delegation prompt with multiple distinct "Check A / Check B" sections without explicitly stating the subagent should perform all checks directly itself.
+- A task-notification result consisting of meta-commentary ("I'll wait for the background agent", "the audit is running in the background") rather than actual findings — that phrasing means the "agent" is a coordinator that itself spawned more agents instead of doing the work.
+- A burst of many task-notifications arriving in immediate succession after only 2-3 Agent calls were made.
+
+</bounded-delegation-prohibit-recursive-subagent-spawn>
 
 <memory-only-knowledge-does-not-transfer-to-subagent>
 


### PR DESCRIPTION
Closes #1528

## 変更内容

`skills/task-subagent-delegation/SKILL.md` に「Bounded delegation: prohibit recursive subagent spawn」セクションを新規追加。委譲 prompt 作成時、Agent tool を持つ subagent (`general-purpose` 等) へ bounded read-only investigation (audit / consistency check 等) を委譲する場合、「これ以上 subagent を生成するな」という明示を求めるルール。

併せて:
- frontmatter description を拡張し、bounded read-only investigation の委譲でもこの skill が発火するようにスコープを広げた (brake 1 Axis A 指摘反映)
- procedure ではなく tool-authority bound であることを明示する一文を追加し、Rules セクションの "do not convey: step-by-step procedure" との緊張を解消 (brake 1 Axis B 指摘反映、3/3 evaluator が同一指摘)

## 背景

2026-07-06、scheduled evolution タスクの full-refactor audit ステップで、read-only な監査作業を 3 並列の `general-purpose` subagent に委譲したところ、委譲 prompt に Agent tool 禁止の明示が無かったため 3/3 全てが自発的に孫 Agent を生成し、一部はさらに孫の孫まで生成。15+ のバックグラウンドタスク通知が発生し API rate limit に到達、成果物を得られたのは当初 3 体中 1 体のみだった (ワークスペースメモリ `feedback_subagent_delegation_recursive_cascade.md` に記録済み)。

## brake 1 結果 (N=3, opus, M=all axes)

- Axis A (application-moment triggering): PASS / PASS / PARTIAL — PARTIAL は上記 description スコープの指摘、反映済み
- Axis B (既存セクションとの整合性): PASS(minor note) / PARTIAL / PASS(minor note) — 3/3 が同一の procedure 文言との緊張を指摘、反映済み
- Axis C (impression-literal detection, fixed axis): none flagged (3/3)

全評価者が "mergeable" と判定。2点の軽微な指摘は反映済みのため再evaluationは実施せず、本コメントに記録する。

## スコープ

L3-task layer の spec 修正。L1 Model Layer には触れないため brake 2 (L1 root-criteria evaluator) は対象外。release-version-rule.md 上は patch 相当 (delegation prompt hygiene の内部ルール追加、user/system observable な大規模構造変更ではない)。