### PR TITLE
fix(adapter): make webhook trailer updates idempotent

### DIFF
--- a/Li+update.md
+++ b/Li+update.md
@@ -154,7 +154,21 @@ Adapter, rules, skills, and hooks generation. Rules/skills generation doubles as
      - Extract the tag from the sentinel (e.g. "Li+ BEGIN (build-2026-03-30.14)" -> "build-2026-03-30.14").
      - If extracted tag matches current target tag: skip (up to date).
      - If tag differs or is absent: replace the section between "Li+ BEGIN" and "Li+ END" (inclusive)
-       with the current adapter source contents. Preserve content outside this section.
+       with the current adapter source contents. Preserve content outside this section, subject to
+       the legacy webhook trailer migration below. The replacement span ends at the final byte of
+       `Li+ END`; do not add the adapter source EOF newline to the preserved target suffix.
+     - Legacy webhook trailer migration: the current adapter source owns its `## Optional Webhook
+       Notification Flow` block inside the sentinel. Before assembling the replacement, derive the
+       legacy block as that complete source block (heading through its final line before `Li+ END`).
+       Run this migration only when the old sentinel section contains no webhook heading; that is
+       the pre-migration ownership shape. From the old target suffix immediately after its `Li+ END`,
+       remove every consecutive byte-exact legacy trailer. One trailer is exactly its two leading
+       separator newlines, the legacy block, and the block's final newline. Stop at the first
+       non-matching bytes and preserve that suffix verbatim; do not normalize line endings to make a
+       match. This removes duplicated trailers written by pre-migration versions without deleting a
+       matching block later added by the user outside a canonical sentinel. Re-applying a later tag
+       skips migration because the old section already owns the webhook block, so the result has
+       exactly one webhook heading for the migrated layout.
   c. If target file exists but does not contain "Li+ BEGIN": ask user -- append Li+ section or skip?
 
 4c.2. Generate .claude/rules/ files (recursive directory mirror):
@@ -290,7 +304,21 @@ grant trust in the GUI. See `docs/D.-Installation.md` for the step-by-step.
      - Extract the tag from the sentinel (e.g. "Li+ BEGIN (build-2026-03-30.14)" -> "build-2026-03-30.14").
      - If extracted tag matches current target tag: skip (up to date).
      - If tag differs or is absent: replace the section between "Li+ BEGIN" and "Li+ END" (inclusive)
-       with the current adapter source contents. Preserve content outside this section.
+       with the current adapter source contents. Preserve content outside this section, subject to
+       the legacy webhook trailer migration below. The replacement span ends at the final byte of
+       `Li+ END`; do not add the adapter source EOF newline to the preserved target suffix.
+     - Legacy webhook trailer migration: the current adapter source owns its `## Optional Webhook
+       Notification Flow` block inside the sentinel. Before assembling the replacement, derive the
+       legacy block as that complete source block (heading through its final line before `Li+ END`).
+       Run this migration only when the old sentinel section contains no webhook heading; that is
+       the pre-migration ownership shape. From the old target suffix immediately after its `Li+ END`,
+       remove every consecutive byte-exact legacy trailer. One trailer is exactly its two leading
+       separator newlines, the legacy block, and the block's final newline. Stop at the first
+       non-matching bytes and preserve that suffix verbatim; do not normalize line endings to make a
+       match. This removes duplicated trailers written by pre-migration versions without deleting a
+       matching block later added by the user outside a canonical sentinel. Re-applying a later tag
+       skips migration because the old section already owns the webhook block, so the result has
+       exactly one webhook heading for the migrated layout.
   c. If target file exists but does not contain "Li+ BEGIN": ask user -- append Li+ section or skip?
 - Note (32 KiB cap): the root AGENTS.md holds only the minimal always-present core
   (identity / character / startup contract). The full rule set arrives via the

--- a/adapter/claude/CLAUDE.md
+++ b/adapter/claude/CLAUDE.md
@@ -190,9 +190,9 @@ Evolution_Initiator_Autonomy:
 
   Detailed spec + exclusion scope: see `rules/evolution/initiator-autonomy.md` and `rules/evolution/autonomy-block-shape.md`.
 
-# --- Li+ END ---
-
 ## Optional Webhook Notification Flow
 
 Webhook intake policy and procedures: `skills/operations-foreground-webhook-intake/SKILL.md`.
 Delivery mode (`poll` / `channel` / `mcp_hook`) is selected by `LI_PLUS_WEBHOOK_DELIVERY` in `Li+config.md`. Detailed mode behavior, mcp_tool hook entry semantics, and `github-webhook-mcp >= v0.11.3` connection requirement are documented in the skill above and `adapter/claude/hooks-settings.md`.
+
+# --- Li+ END ---

--- a/adapter/codex/AGENTS.md
+++ b/adapter/codex/AGENTS.md
@@ -196,10 +196,10 @@ Evolution_Initiator_Autonomy:
 
   Detailed spec + exclusion scope: see `rules/evolution/initiator-autonomy.md` and `rules/evolution/autonomy-block-shape.md`.
 
-# --- Li+ END ---
-
 ## Optional Webhook Notification Flow
 
 Webhook intake policy and procedures: `skills/operations-foreground-webhook-intake/SKILL.md`.
 Delivery mode (`poll` / `channel` / `mcp_hook`) is selected by `LI_PLUS_WEBHOOK_DELIVERY` in `Li+config.md`. Detailed mode behavior and `github-webhook-mcp >= v0.11.3` connection requirement are documented in the skill above and `adapter/codex/hooks-config.md`.
 Codex specifics: the Codex hooks schema documents only `type: "command"` handlers (no `type: "mcp_tool"` entry like Claude's `settings.json`), so the Codex adapter stays on `poll` — the `on-user-prompt` hook emits the reminder and the AI calls `mcp__github-webhook-mcp__get_pending_status` itself. Setting `channel` / `mcp_hook` only suppresses the reminder text; a Codex host without an equivalent realtime substrate falls back to `poll`.
+
+# --- Li+ END ---

--- a/docs/C.-Update.md
+++ b/docs/C.-Update.md
@@ -129,7 +129,8 @@ Li+config.md にはトークンが含まれるため、ファイルパーミッ�
 - ファイルが存在し `Li+ BEGIN` sentinel を含む:
   - sentinel 内のタグ（例 `Li+ BEGIN (build-2026-03-30.14)` → `build-2026-03-30.14`）を抽出
   - 現在のターゲットタグと一致 → スキップ（最新）
-  - 不一致またはタグなし → `Li+ BEGIN` 〜 `Li+ END` 間（両端含む）をソース内容で差し替え、セクション外は保護
+  - 不一致またはタグなし → `Li+ BEGIN` 〜 `Li+ END` 間（両端含む）をソース内容で差し替え、下記 legacy webhook trailer migration を除く sentinel 外は保護。置換 byte span は `Li+ END` の最終 byte で終え、adapter source の EOF newline を保持する target suffix へ追加しない
+  - legacy webhook trailer migration: 現行 adapter source が `## Optional Webhook Notification Flow` block を sentinel 内で所有する。migration は旧 sentinel section に webhook heading が無い pre-migration 所有形状だけで実行する。差し替え前に source の当該 heading から `Li+ END` 直前までを legacy block として取得し、旧 target の `Li+ END` 直後の suffix から、先頭の2個の separator newline、legacy block、block末尾 newline までを1件とする連続した byte-exact legacy trailer だけを除去する。最初の不一致 byte で停止し、line ending を正規化して一致させず、以後の suffix はそのまま保持する。これにより pre-migration 版が残した重複 trailer を除去しつつ、canonical sentinel の外へ後から追加された同一 block を削除しない。後続 tag を再適用した時は旧 section が既に heading を所有するため migration を skip し、migrated layout の webhook heading は置換 section 内の1件だけになる
 - ファイルが存在するが sentinel なし → ユーザーに確認（Li+ セクションを追記 or スキップ）
 
 **4c.2. `.claude/rules/` ファイル生成（再帰ディレクトリミラー）**
@@ -227,7 +228,7 @@ Codex ホストでは Phase 4 claude branch と同型に adapter / skills / hook
 **4x.1. アダプターの bootstrap**
 
 - target = `{workspace_root}/AGENTS.md`, source = `adapter/codex/AGENTS.md`
-- sentinel 判定ロジックは 4c.1 と同一（存在しなければ新規、sentinel ありタグ一致でスキップ、不一致で section 差し替え、sentinel なしでユーザー確認）
+- sentinel 判定ロジックは 4c.1 と同一（存在しなければ新規、sentinel ありタグ一致でスキップ、不一致で section 差し替え、sentinel なしでユーザー確認）。差し替え時の legacy webhook trailer migration も4c.1と同一で、旧 section が heading を持たない時だけ、連続する byte-exact legacy trailer を `Li+ END` 直後から除去し、canonical sentinel 外のユーザー作成 suffix を保持する
 - 32 KiB 上限: ルートの AGENTS.md は最小コア（identity / character / 起動契約）のみを保持。rules 全体は 4x.3 の SessionStart hook 注入で届くため inline しない（Codex の `project_doc_max_bytes` 既定 32 KiB を超えないため）
 
 **4x.2. `.agents/skills/` ファイル生成（flat ディレクトリミラー）**

--- a/tests/test_adapter_update_contract.py
+++ b/tests/test_adapter_update_contract.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SENTINEL_BEGIN = b"# --- Li+ BEGIN ("
+SENTINEL_END = b"# --- Li+ END ---"
+WEBHOOK_HEADING = b"## Optional Webhook Notification Flow"
+# Exact external trailer bodies from pre-migration commit 509fd0e.
+KNOWN_LEGACY_BODIES = {
+    "claude/CLAUDE.md": (
+        "## Optional Webhook Notification Flow\n\n"
+        "Webhook intake policy and procedures: `skills/operations-foreground-webhook-intake/SKILL.md`.\n"
+        "Delivery mode (`poll` / `channel` / `mcp_hook`) is selected by `LI_PLUS_WEBHOOK_DELIVERY` in `Li+config.md`. Detailed mode behavior, mcp_tool hook entry semantics, and `github-webhook-mcp >= v0.11.3` connection requirement are documented in the skill above and `adapter/claude/hooks-settings.md`."
+    ).encode("utf-8"),
+    "codex/AGENTS.md": (
+        "## Optional Webhook Notification Flow\n\n"
+        "Webhook intake policy and procedures: `skills/operations-foreground-webhook-intake/SKILL.md`.\n"
+        "Delivery mode (`poll` / `channel` / `mcp_hook`) is selected by `LI_PLUS_WEBHOOK_DELIVERY` in `Li+config.md`. Detailed mode behavior and `github-webhook-mcp >= v0.11.3` connection requirement are documented in the skill above and `adapter/codex/hooks-config.md`.\n"
+        "Codex specifics: the Codex hooks schema documents only `type: \"command\"` handlers (no `type: \"mcp_tool\"` entry like Claude's `settings.json`), so the Codex adapter stays on `poll` \u2014 the `on-user-prompt` hook emits the reminder and the AI calls `mcp__github-webhook-mcp__get_pending_status` itself. Setting `channel` / `mcp_hook` only suppresses the reminder text; a Codex host without an equivalent realtime substrate falls back to `poll`."
+    ).encode("utf-8"),
+}
+
+
+def split_sentinel_section(text: bytes) -> tuple[bytes, bytes, bytes]:
+    start = text.index(SENTINEL_BEGIN)
+    end = text.index(SENTINEL_END, start) + len(SENTINEL_END)
+    return text[:start], text[start:end], text[end:]
+
+
+def legacy_webhook_body(adapter_source: bytes) -> bytes:
+    _, section, _ = split_sentinel_section(adapter_source)
+    start = section.index(WEBHOOK_HEADING)
+    return section[start : section.rindex(SENTINEL_END)].rstrip(b"\r\n")
+
+
+def legacy_webhook_trailer(adapter_source: bytes) -> bytes:
+    return b"\n\n" + legacy_webhook_body(adapter_source) + b"\n"
+
+
+def known_legacy_webhook_trailer(adapter: str) -> bytes:
+    return b"\n\n" + KNOWN_LEGACY_BODIES[adapter] + b"\n"
+
+
+def remove_legacy_trailers(suffix: bytes, trailer: bytes) -> bytes:
+    while suffix.startswith(trailer):
+        suffix = suffix[len(trailer) :]
+    return suffix
+
+
+def apply_adapter_update(installed: bytes, adapter_source: bytes) -> bytes:
+    prefix, old_section, suffix = split_sentinel_section(installed)
+    if WEBHOOK_HEADING not in old_section:
+        suffix = remove_legacy_trailers(suffix, legacy_webhook_trailer(adapter_source))
+    _, source_section, _ = split_sentinel_section(adapter_source)
+    return prefix + source_section + suffix
+
+
+class AdapterUpdateContractTest(unittest.TestCase):
+    def adapter_source(self, adapter: str, tag: str) -> bytes:
+        source = (ROOT / "adapter" / adapter).read_bytes()
+        return source.replace(b"{LI_PLUS_TAG}", tag.encode("ascii"))
+
+    def legacy_installed(self, adapter: str, tag: str) -> bytes:
+        source = self.adapter_source(adapter, tag)
+        _, section, _ = split_sentinel_section(source)
+        start = section.index(WEBHOOK_HEADING)
+        old_section = section[:start].rstrip(b"\r\n") + b"\n\n" + SENTINEL_END
+        trailer = known_legacy_webhook_trailer(adapter)
+        return old_section + trailer + trailer + b"\nuser-owned suffix\n"
+
+    def test_webhook_flow_is_owned_by_each_adapter_sentinel(self) -> None:
+        for adapter in ("claude/CLAUDE.md", "codex/AGENTS.md"):
+            source = self.adapter_source(adapter, "build-current")
+            _, section, suffix = split_sentinel_section(source)
+            self.assertEqual(section.count(WEBHOOK_HEADING), 1)
+            self.assertEqual(suffix.count(WEBHOOK_HEADING), 0)
+            self.assertEqual(legacy_webhook_body(source), KNOWN_LEGACY_BODIES[adapter])
+
+    def test_sequential_tag_updates_remove_legacy_duplicates_and_preserve_user_suffix(self) -> None:
+        for adapter in ("claude/CLAUDE.md", "codex/AGENTS.md"):
+            installed = self.legacy_installed(adapter, "build-old")
+            updated = apply_adapter_update(installed, self.adapter_source(adapter, "build-next"))
+            updated_again = apply_adapter_update(updated, self.adapter_source(adapter, "build-later"))
+
+            self.assertEqual(updated.count(WEBHOOK_HEADING), 1)
+            self.assertEqual(updated_again.count(WEBHOOK_HEADING), 1)
+            _, next_section, _ = split_sentinel_section(self.adapter_source(adapter, "build-next"))
+            _, later_section, _ = split_sentinel_section(self.adapter_source(adapter, "build-later"))
+            self.assertEqual(updated, next_section + b"\nuser-owned suffix\n")
+            self.assertEqual(updated_again, later_section + b"\nuser-owned suffix\n")
+            self.assertTrue(updated_again.endswith(b"\nuser-owned suffix\n"))
+            self.assertIn(b"build-later", updated_again)
+
+    def test_canonical_section_preserves_an_external_matching_user_block(self) -> None:
+        for adapter in ("claude/CLAUDE.md", "codex/AGENTS.md"):
+            source = self.adapter_source(adapter, "build-current")
+            user_suffix = known_legacy_webhook_trailer(adapter) + b"\nuser-owned suffix\n"
+            updated = apply_adapter_update(source + user_suffix, self.adapter_source(adapter, "build-later"))
+
+            self.assertTrue(updated.endswith(user_suffix))
+            self.assertEqual(updated.count(WEBHOOK_HEADING), 2)
+
+    def test_non_byte_exact_legacy_suffix_is_preserved_without_normalization(self) -> None:
+        for adapter in ("claude/CLAUDE.md", "codex/AGENTS.md"):
+            legacy = self.legacy_installed(adapter, "build-old")
+            _, old_section, _ = split_sentinel_section(legacy)
+            crlf_trailer = known_legacy_webhook_trailer(adapter).replace(b"\n", b"\r\n")
+            installed = old_section + crlf_trailer + b"user-owned suffix\n"
+            updated = apply_adapter_update(installed, self.adapter_source(adapter, "build-next"))
+
+            self.assertTrue(updated.endswith(crlf_trailer + b"user-owned suffix\n"))
+            self.assertEqual(updated.count(WEBHOOK_HEADING), 2)
+
+    def test_update_contract_requires_byte_exact_legacy_migration_for_both_adapters(self) -> None:
+        update = (ROOT / "Li+update.md").read_text(encoding="utf-8")
+        self.assertEqual(update.count("Legacy webhook trailer migration:"), 2)
+        self.assertEqual(update.count("pre-migration ownership shape"), 2)
+        self.assertEqual(update.count("byte-exact legacy trailer"), 2)
+        self.assertEqual(update.count("preserve that suffix verbatim"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1548
Webhook trailerをsentinel内へ移し、旧版の重複trailerを安全に移行する。
連続tag適用、suffix保持、CRLF非一致を回帰テストで検証する。