### PR TITLE
fix(operations): assign authenticated AI actor

### DIFF
--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -142,8 +142,8 @@ remote: gh api repos/{owner}/{repo}/branches/{branch-name}  # 404 = not exists
 # ブランチ作成 + issue リンク
 gh issue develop {issue_number} -R {owner}/{repo} --name {session-branch} --base main
 
-# アサイニー設定
-gh api repos/{owner}/{repo}/issues/{issue_number}/assignees --method POST -f 'assignees[]=liplus-lin-lay'
+# 実行中の GitHub CLI 認証 actor をアサイニーに設定
+gh issue edit {issue_number} -R {owner}/{repo} --add-assignee "@me"
 ```
 
 ローカルエラー時の対処：`gh issue develop` がローカルで失敗してもGitHub 側では成功する場合がある。リンク済みブランチを確認してから判断する。
@@ -265,13 +265,13 @@ single parent PR flow 下では、親 issue も sub-issue と同じく `Closes #
 GitHub の自動クローズキーワード（公式リスト）：`close / closes / closed / fix / fixes / fixed / resolve / resolves / resolved`。`Refs` はクローズキーワードではなく自動クローズしない。マージ時にクローズさせたい issue には `Refs` を使わない。
 
 PR 作成後：
-1. AI bot を PR の assignee に self-assign する：
+1. 実行中の GitHub CLI 認証 actor を PR の assignee に self-assign する：
 
    ```
-   gh pr edit {pr} -R {owner}/{repo} --add-assignee liplus-lin-lay
+   gh pr edit {pr} -R {owner}/{repo} --add-assignee "@me"
    ```
 
-   目的：issue 側の assignee は PR エンティティに自動継承されないため、PR の Assignees フィールドに AI bot を明示し「この PR は AI が owner」という UI 上の trail を残す。
+   目的：issue 側の assignee は PR エンティティに自動継承されないため、PR の Assignees フィールドに実行中の認証 actor を明示し「この PR は AI が owner」という UI 上の trail を残す。
    メカニズム注記：GitHub は `--add-reviewer` の自己指定を silent に拒否するが、`--add-assignee` による PR author 自身の assignee 追加は許可される（2026-04-20 に PR #1099 で empirical 検証済）。
    スコープ：assignee self-assign は UI trail のためであり、正式な self-review 記録（`gh pr review --comment`、「PR レビュー」節参照）を置き換えるものではない。
 

--- a/skills/operations-on-branch/SKILL.md
+++ b/skills/operations-on-branch/SKILL.md
@@ -47,7 +47,7 @@ If not exists   = proceed normally.
 
 Branch creation:
 command  = gh issue develop {issue_number} -R {owner}/{repo} --name {session-branch} --base main
-assignee = gh api repos/{owner}/{repo}/issues/{issue_number}/assignees --method POST -f 'assignees[]=liplus-lin-lay'
+assignee = gh issue edit {issue_number} -R {owner}/{repo} --add-assignee "@me"
 
 Merge behavior:
 PR merge auto-closes the parent issue via issue reference.

--- a/skills/operations-on-pr-creation/SKILL.md
+++ b/skills/operations-on-pr-creation/SKILL.md
@@ -32,8 +32,8 @@ PR body format:
 Detail belongs in issue, not in PR.
 
 On PR created:
-1 = self-assign AI bot to PR assignees:
-    gh pr edit {pr} -R {owner}/{repo} --add-assignee liplus-lin-lay
+1 = self-assign the authenticated GitHub CLI actor to PR assignees:
+    gh pr edit {pr} -R {owner}/{repo} --add-assignee "@me"
     rationale: existing issue-side assignee does not auto-propagate to the PR entity. Self-assign makes "AI owns this PR" explicit in the Assignees field.
     mechanism note: GitHub rejects `--add-reviewer` self-assignment silently, but allows `--add-assignee` self-assign for PR author (empirically verified 2026-04-20 on PR #1099).
     scope: assignee self-assign is UI trail only; it does not replace the formal self-review record (`gh pr review --comment`, see [PR Review]).


### PR DESCRIPTION
Closes #1617

Issue / PR の self-assignee を固定アカウントから GitHub CLI の @me に変更し、実行中の認証 actor を割り当てる。
source skill と docs/4.-Operations.md を同期し、UI owner trail と正式 self-review の境界を維持する。
Release type: patch