### PR TITLE
fix(task): align delegation body language contract

### DIFF
--- a/docs/3.-Task.md
+++ b/docs/3.-Task.md
@@ -278,6 +278,12 @@ issue / commit / PR の形式に適用する。
 
 （→ `skills/task-subagent-delegation/SKILL.md`。L3 Task Layer。トリガー時ロード。発火の瞬間で分割しており、委任プロンプト作成は `skills/task-subagent-prompt/SKILL.md`、spawn パラメータ（model 方針 / 並列幅上限）は `skills/task-subagent-spawn/SKILL.md`、subagent 側の state-machine label は `skills/task-subagent-state-labels/SKILL.md`）
 
+### 委譲プロンプトの成果物言語
+
+委譲プロンプトに成果物の例を含める場合、issue / PR / commit のタイトル例は ASCII 英語のみとする。body の例（issue / PR / commit body と wiki entry）は、対象成果物に適用される言語契約に従う。言語は、対象成果物への human の明示指示、thread で受容済みの合意、対象 repository / workspace の project-language default の順で解決し、対象 repository 固有の governance も同時に満たす。
+
+host workspace の言語契約は `LI_PLUS_REPO` の governance を上書きしない。liplus-language では issue / PR / commit body に日本語を含める。body は well-formed UTF-8 であり mojibake なく表示されることを検証し、ASCII-only 検証を適用しない。
+
 ### ルール
 
 **実装は常にサブエージェントへ委譲する。親は実装しない。** 適用範囲は Li+ 全体であり、`LI_PLUS_REPO` の自己進化 PR も `USER_REPO<N>` のユーザーリポジトリも同じ。差分サイズによる例外を置かない。例外条項は適用の瞬間に判断を要求し、判断軸である規則の単純さを崩すためである（判断記録は wiki `implementation-always-delegated`）。受容した対価は、親が brake の指摘を裁く時点で文脈を報告から組み直すことと、1行の変更でも委譲プロンプトの作成コストが乗ること。この規則が委譲する「実装」は PR が開く前に作られる issue の変更であり、CI green 後に親が brake の指摘を受けて行う修正は判定の内側にあたる（再委譲の点ではない。位置の正本は `rules/evolution/initiator-autonomy.md` Two-stage brake）。ただしその修正は指摘の範囲に閉じる——親が入れてよいのは裁いた指摘が要求する変更だけであり、それを越える作業は実装であって、大きさに関わらずサブエージェントへ戻る。さもなければ、薄い委譲実装のあとに親が大幅に書き直す形で、サイズ軸で否定した例外が「判定」の名前で戻ってくる。

--- a/skills/task-subagent-delegation/SKILL.md
+++ b/skills/task-subagent-delegation/SKILL.md
@@ -72,7 +72,7 @@ This is a substrate-absence fallback, not an exception to the always-delegate ru
 
 This skill covers the decision to delegate and the split of what each side executes. Three adjacent moments have their own skills; do not restate them here.
 
-- Composing the delegation prompt (mode-specific injection, ASCII-only example text, recursive-spawn prohibition, memory-does-not-transfer) → `skills/task-subagent-prompt/SKILL.md`.
+- Composing the delegation prompt (mode-specific injection, field-scoped title/body language hygiene, recursive-spawn prohibition, memory-does-not-transfer) → `skills/task-subagent-prompt/SKILL.md`.
 - Setting the Agent tool spawn parameters (model policy, parallel-width cap) → `skills/task-subagent-spawn/SKILL.md`.
 - Subagent-side state-machine label transitions at role boundaries → `skills/task-subagent-state-labels/SKILL.md`.
 

--- a/skills/task-subagent-delegation/SKILL.md
+++ b/skills/task-subagent-delegation/SKILL.md
@@ -72,7 +72,7 @@ This is a substrate-absence fallback, not an exception to the always-delegate ru
 
 This skill covers the decision to delegate and the split of what each side executes. Three adjacent moments have their own skills; do not restate them here.
 
-- Composing the delegation prompt (mode-specific injection, field-scoped title/body language hygiene, recursive-spawn prohibition, memory-does-not-transfer) → `skills/task-subagent-prompt/SKILL.md`.
+- Composing the delegation prompt (mode-specific injection, destination-governed title/body language hygiene, recursive-spawn prohibition, memory-does-not-transfer) → `skills/task-subagent-prompt/SKILL.md`.
 - Setting the Agent tool spawn parameters (model policy, parallel-width cap) → `skills/task-subagent-spawn/SKILL.md`.
 - Subagent-side state-machine label transitions at role boundaries → `skills/task-subagent-state-labels/SKILL.md`.
 

--- a/skills/task-subagent-prompt/SKILL.md
+++ b/skills/task-subagent-prompt/SKILL.md
@@ -10,7 +10,7 @@ layer: L3-task
 
 The minimal "issue URL only" pattern works for `auto` and `semi_auto` because the subagent's auto-loaded operations rules already cover the merge gate. `trigger` mode is the exception: the merge gate involves human approval timing, and three pieces of context need explicit injection because they are parent-side decisions, not subagent-discovered facts:
 
-- (a) commit body language: project-language constraint (e.g. Japanese for liplus-language). Auto-loaded operations.md states the rule, but missed-application is the recurring failure mode; explicit reminder in the delegation prompt prevents drift.
+- (a) commit body language: the destination artifact's governing language contract and repository governance (liplus-language requires Japanese). Auto-loaded operations.md states the repository rule, but missed-application is the recurring failure mode; explicit reminder in the delegation prompt prevents drift.
 - (b) auto-merge enablement: include `gh pr merge {pr} --auto --squash` as a step the subagent runs after PR creation. Without this, the merge sits idle after human approval because trigger-mode PRs do not auto-merge by default.
 - (c) stop condition: the `trigger` form is longer than the `auto` / `semi_auto` one and ends short of merge complete. Read it at `skills/operations-on-pr-review/SKILL.md` Delegated-subagent stop condition, which splits by mode; inject that mode's literal into the prompt. Do not restate it here.
 
@@ -22,20 +22,23 @@ These three are out of scope for the broader "do not convey procedure" rule (`sk
 
 # Delegation prompt hygiene (field-scoped artifact language)
 
-Example artifact text MUST follow the destination field's language contract; being example text does not create an independent ASCII-only category. Issue / PR / commit title examples MUST be ASCII-only. Body examples (issue / PR / commit / wiki entry) MUST follow `LI_PLUS_PROJECT_LANGUAGE` and MUST NOT be rewritten under an ASCII-only rule. In liplus-language, issue / PR / commit body examples therefore contain Japanese where governance requires it.
+Example artifact text MUST follow the destination artifact's governing language contract; being example text does not create an independent ASCII-only category. Resolve the language from (1) an explicit human language instruction for that artifact, (2) an accepted thread agreement, then (3) the destination repository / workspace project-language default (`LI_PLUS_PROJECT_LANGUAGE` when applicable), while also satisfying destination-repository governance. A host workspace language contract does not override `LI_PLUS_REPO` governance.
 
-Subagents mirror the prompt's literal style when emitting artifacts. Non-ASCII typographic characters (em-dash `—` / en-dash `–` / box-drawing `─` / smart quotes `' " ' "` / JA characters in example titles) can leak from a prompt into an ASCII-governed title field. Body fields are validated as well-formed UTF-8 that renders without mojibake, not as ASCII byte sequences.
+Issue / PR / commit title examples MUST be ASCII English only. Body examples (issue / PR / commit bodies and wiki entries) MUST follow the resolved governing language contract and MUST NOT be rewritten under an ASCII-only rule. In liplus-language, issue / PR / commit bodies contain Japanese as required by repository governance.
+
+Subagents mirror the prompt's literal style when emitting artifacts. Non-ASCII typographic characters (em-dash `—` / en-dash `–` / box-drawing `─` / smart quotes `' " ' "` / JA characters in example titles) can leak from a prompt into an ASCII-English-governed title field. Body fields are validated as well-formed UTF-8 that renders without mojibake, not as ASCII byte sequences.
 
 How to apply:
-- For issue / PR / commit title examples, substitute ASCII before sending the prompt: em-dash -> `-` / `--`, en-dash -> `-`, box-drawing horizontal -> `-` / `=`, smart quotes -> ASCII `'` `"`, JA-in-example-title -> romanize or omit.
-- For body examples, use `LI_PLUS_PROJECT_LANGUAGE`; validate well-formed UTF-8 and inspect rendered text for mojibake. Do not use an ASCII-only check as body validation.
-- Add an explicit instruction to the prompt: "Use ASCII characters only in issue, PR, and commit titles. Bodies must follow LI_PLUS_PROJECT_LANGUAGE; do not apply an ASCII-only rule to issue, PR, commit, wiki, or entry bodies. Apply `od -c` byte-level verification to title fields, and verify body text is well-formed UTF-8 and renders without mojibake."
-- The prompt's surrounding prose may use non-ASCII (em-dash for English reading efficiency is fine); every example field the subagent might copy follows its own destination-field contract.
+- For issue / PR / commit title examples, rewrite into ASCII English before sending the prompt: em-dash -> `-` / `--`, en-dash -> `-`, box-drawing horizontal -> `-` / `=`, smart quotes -> ASCII `'` `"`, and JA example-title text -> translate / rewrite into ASCII English or omit.
+- For issue / PR / commit body and wiki-entry examples, resolve the destination artifact's governing language contract using the precedence above; validate well-formed UTF-8 and inspect rendered text for mojibake. Do not use an ASCII-only check as body validation.
+- Add an explicit instruction to the prompt: "Use ASCII English only in issue, PR, and commit titles. Resolve issue/PR/commit bodies and wiki entries from each destination artifact's governing language contract: an explicit human language instruction for that artifact, then an accepted thread agreement, then the destination repository/workspace project-language default, while satisfying destination-repository governance. The host workspace language contract does not override LI_PLUS_REPO governance; in liplus-language, issue/PR/commit bodies require Japanese. Never apply an ASCII-only rule to bodies. Apply `od -c` byte-level verification to title fields, and verify body text is well-formed UTF-8 and renders without mojibake."
+- The prompt's surrounding prose is outside title-field ASCII checks; every example field the subagent might copy follows its own destination-field contract.
 
 Detection signs:
-- About to write `—` or `──` in an ASCII-governed example title inside the delegation prompt.
+- About to write `—` or `──` in an ASCII-English-governed example title inside the delegation prompt.
 - Example PR title field contains JA characters or smart quotes.
-- Example body is forced to ASCII or omits the project language required for that body.
+- Example body is forced to ASCII or omits the resolved governing language contract or destination-repository governance.
+- A host workspace language default is used to override `LI_PLUS_REPO` governance.
 - `od -c` or another byte-level ASCII check is applied to body content as an acceptance criterion instead of UTF-8 / mojibake validation.
 - One instruction groups title and body fields under the same ASCII-only clause.
 

--- a/skills/task-subagent-prompt/SKILL.md
+++ b/skills/task-subagent-prompt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-subagent-prompt
-description: Invoke when a subagent delegation prompt is being composed / example artifact text such as a suggested PR title or commit body is about to be written into a delegation prompt / a delegation runs in trigger execution mode and merge-gate context must be injected / subagent behavior depends on something that exists only in parent-side memory / a bounded read-only investigation prompt is being written and recursive subagent spawn must be prohibited. Provides the mode-specific injection items for trigger mode, ASCII-only hygiene for quotable example text, the recursive-spawn prohibition literal, and the memory-does-not-transfer rule with its injection or promotion cure.
+description: Invoke when a subagent delegation prompt is being composed / example artifact text such as a suggested PR title or commit body is about to be written into a delegation prompt / a delegation runs in trigger execution mode and merge-gate context must be injected / subagent behavior depends on something that exists only in parent-side memory / a bounded read-only investigation prompt is being written and recursive subagent spawn must be prohibited. Provides the mode-specific injection items for trigger mode, field-scoped language hygiene for quotable example text, the recursive-spawn prohibition literal, and the memory-does-not-transfer rule with its injection or promotion cure.
 layer: L3-task
 ---
 
@@ -18,24 +18,28 @@ These three are out of scope for the broader "do not convey procedure" rule (`sk
 
 </mode-specific-delegation-injection>
 
-<delegation-prompt-hygiene-ascii-only-example-text>
+<delegation-prompt-hygiene-field-scoped-language>
 
-# Delegation prompt hygiene (ASCII-only example text)
+# Delegation prompt hygiene (field-scoped artifact language)
 
-Any example text the subagent may quote into an artifact (suggested PR title / commit title / commit body / wiki entry / issue body) MUST be ASCII-only. Subagents mirror the prompt's literal style when emitting artifacts; non-ASCII typographic characters (em-dash `—` / en-dash `–` / box-drawing `─` / smart quotes `' " ' "` / JA characters in example PR titles) leak through and persist in merged artifacts because governance CI checks PR titles only — commit bodies, wiki entry bodies, and issue bodies are not byte-checked.
+Example artifact text MUST follow the destination field's language contract; being example text does not create an independent ASCII-only category. Issue / PR / commit title examples MUST be ASCII-only. Body examples (issue / PR / commit / wiki entry) MUST follow `LI_PLUS_PROJECT_LANGUAGE` and MUST NOT be rewritten under an ASCII-only rule. In liplus-language, issue / PR / commit body examples therefore contain Japanese where governance requires it.
+
+Subagents mirror the prompt's literal style when emitting artifacts. Non-ASCII typographic characters (em-dash `—` / en-dash `–` / box-drawing `─` / smart quotes `' " ' "` / JA characters in example titles) can leak from a prompt into an ASCII-governed title field. Body fields are validated as well-formed UTF-8 that renders without mojibake, not as ASCII byte sequences.
 
 How to apply:
-- Substitute ASCII before sending the prompt: em-dash -> `-` / `--`, en-dash -> `-`, box-drawing horizontal -> `-` / `=`, smart quotes -> ASCII `'` `"`, JA-in-example-PR-title -> romanize or omit.
-- Add an explicit instruction to the prompt: "Use ASCII characters only in PR titles, commit titles/bodies, and entry body text. Apply `od -c` byte-level verification to BOTH titles AND body content text."
-- The prompt's surrounding prose may use non-ASCII (em-dash for English reading efficiency is fine); the *example text fields* the subagent might copy must be ASCII.
+- For issue / PR / commit title examples, substitute ASCII before sending the prompt: em-dash -> `-` / `--`, en-dash -> `-`, box-drawing horizontal -> `-` / `=`, smart quotes -> ASCII `'` `"`, JA-in-example-title -> romanize or omit.
+- For body examples, use `LI_PLUS_PROJECT_LANGUAGE`; validate well-formed UTF-8 and inspect rendered text for mojibake. Do not use an ASCII-only check as body validation.
+- Add an explicit instruction to the prompt: "Use ASCII characters only in issue, PR, and commit titles. Bodies must follow LI_PLUS_PROJECT_LANGUAGE; do not apply an ASCII-only rule to issue, PR, commit, wiki, or entry bodies. Apply `od -c` byte-level verification to title fields, and verify body text is well-formed UTF-8 and renders without mojibake."
+- The prompt's surrounding prose may use non-ASCII (em-dash for English reading efficiency is fine); every example field the subagent might copy follows its own destination-field contract.
 
 Detection signs:
-- About to write `—` or `──` in an example title / body field inside the delegation prompt.
+- About to write `—` or `──` in an ASCII-governed example title inside the delegation prompt.
 - Example PR title field contains JA characters or smart quotes.
-- Re-reading own prompt: surrounding prose mixes typographic chars freely while example fields inherit the same mix.
-- Subagent reports "pre-existing em-dash found in previously-merged artifact" — the propagation already happened.
+- Example body is forced to ASCII or omits the project language required for that body.
+- `od -c` or another byte-level ASCII check is applied to body content as an acceptance criterion instead of UTF-8 / mojibake validation.
+- One instruction groups title and body fields under the same ASCII-only clause.
 
-</delegation-prompt-hygiene-ascii-only-example-text>
+</delegation-prompt-hygiene-field-scoped-language>
 
 <bounded-delegation-prohibit-recursive-subagent-spawn>
 


### PR DESCRIPTION
Closes #1561
委譲プロンプトのtitle例をASCII英語に限定し、body例は対象成果物のgoverning language contractで解決する。
human明示指示、thread合意、対象project defaultのprecedenceとLI_PLUS_REPO governanceの独立制約を明記し、UTF-8・mojibake検証へ切り分ける。
docs/3.-Task.mdをrequirements ownerとして同じfield-scoped契約へ同期する。
Release type: patch