### PR TITLE
spec(operations): state the issue reference form in the rule literal [rules, docs]

### DIFF
--- a/docs/3.-Task.md
+++ b/docs/3.-Task.md
@@ -276,7 +276,7 @@ issue 操作セクションは個別 skill（`skills/operations-on-*/SKILL.md`�
 issue / commit / PR の形式に適用する。
 
 - タイトル：ASCII 英語のみ（識別レイヤー）
-- ボディ：`LI_PLUS_PROJECT_LANGUAGE`（意味レイヤー）+ issue 番号
+- ボディ：`LI_PLUS_PROJECT_LANGUAGE`（意味レイヤー）+ issue 参照（`#<issue番号>`）
 - タイトルは ASCII 英語の固定であり、`LI_PLUS_PROJECT_LANGUAGE` が解決する値ではない（別軸）
 
 ---

--- a/docs/3.-Task.md
+++ b/docs/3.-Task.md
@@ -276,7 +276,7 @@ issue 操作セクションは個別 skill（`skills/operations-on-*/SKILL.md`�
 issue / commit / PR の形式に適用する。
 
 - タイトル：ASCII 英語のみ（識別レイヤー）
-- ボディ：`LI_PLUS_PROJECT_LANGUAGE`（意味レイヤー）+ issue 参照（`#<issue番号>`）
+- ボディ：`LI_PLUS_PROJECT_LANGUAGE`（意味レイヤー）。issue 参照（`#<issue番号>`）は commit / PR のボディに含める
 - タイトルは ASCII 英語の固定であり、`LI_PLUS_PROJECT_LANGUAGE` が解決する値ではない（別軸）
 
 ---

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -59,10 +59,12 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 - コミット単位の CI 可視化は draft PR を親ブランチ上で早期に open することで実現する（PR を分割しない）
 - コミットタイトル = ASCII 英語のみ、1行
 - コミットボディは省略不可
-- コミットボディに含めるもの：変更要約 + 意図または背景 + issue 番号
+- コミットボディに含めるもの：変更要約 + 意図または背景 + issue 参照
 - コミットボディに `LI_PLUS_PROJECT_LANGUAGE` の文を最低1文含める
 - PR タイトル = ASCII 英語のみ、1行
 - PR ボディ = `LI_PLUS_PROJECT_LANGUAGE`
+- PR ボディに issue 参照を含める
+- issue 参照の形式 = `#<issue番号>`。`#` の前置は形式の一部であり、`issue <番号>` や裸の `<番号>` は issue 参照ではない。上記のコミットボディ行と PR ボディ行の両方に適用する
 - 上記2本のタイトル行は body 行とは別の軸に乗る。そこでの ASCII 英語は1行タイトルに対する GitHub 側の慣行であって `LI_PLUS_PROJECT_LANGUAGE` が解決する値ではなく、project language が他の言語である workspace でもタイトルは ASCII 英語のままである。body 行を契約参照として読みながらタイトル行までパラメータ化してしまうのが、この一文が抑える誤読である
 - 実装変更を含む PR は、対応する `docs/` の更新を同一 PR 内に含める。分割は禁止
 - `docs/` を正本とする。Wiki は反映先であり、正本にしない。この行の `docs/` は、リポジトリの番号付き要求仕様書とアルファベット付き参考文書を指す。`skills/evolution-persistence-tiering/SKILL.md` の `docs-tier`（wiki を含む永続度の階層名）とは同じ語で別の軸である

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -64,7 +64,7 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 - PR タイトル = ASCII 英語のみ、1行
 - PR ボディ = `LI_PLUS_PROJECT_LANGUAGE`
 - PR ボディに issue 参照を含める
-- issue 参照の形式 = `#<issue番号>`。`#` の前置は形式の一部であり、`issue <番号>` や裸の `<番号>` は issue 参照ではない。上記のコミットボディ行と PR ボディ行の両方に適用する
+- issue 参照の形式 = `#<issue番号>`。`#` の前置は形式の一部であり、`issue <番号>` や裸の `<番号>` は issue 参照ではない。issue 参照が要求される箇所すべてに適用する
 - 上記2本のタイトル行は body 行とは別の軸に乗る。そこでの ASCII 英語は1行タイトルに対する GitHub 側の慣行であって `LI_PLUS_PROJECT_LANGUAGE` が解決する値ではなく、project language が他の言語である workspace でもタイトルは ASCII 英語のままである。body 行を契約参照として読みながらタイトル行までパラメータ化してしまうのが、この一文が抑える誤読である
 - 実装変更を含む PR は、対応する `docs/` の更新を同一 PR 内に含める。分割は禁止
 - `docs/` を正本とする。Wiki は反映先であり、正本にしない。この行の `docs/` は、リポジトリの番号付き要求仕様書とアルファベット付き参考文書を指す。`skills/evolution-persistence-tiering/SKILL.md` の `docs-tier`（wiki を含む永続度の階層名）とは同じ語で別の軸である

--- a/rules/operations/operations.md
+++ b/rules/operations/operations.md
@@ -62,7 +62,7 @@ Commit body must contain at least one sentence in `LI_PLUS_PROJECT_LANGUAGE`.
 PR title = ASCII English only, single line.
 PR body = `LI_PLUS_PROJECT_LANGUAGE`.
 PR body must contain an issue reference.
-Issue reference form = `#<issue number>`. The `#` prefix is part of the form: `issue <number>` or a bare `<number>` is not an issue reference. Applies to the commit body and PR body lines above.
+Issue reference form = `#<issue number>`. The `#` prefix is part of the form: `issue <number>` or a bare `<number>` is not an issue reference. Applies wherever an issue reference is required.
 The two title lines sit on an axis separate from the body lines: ASCII English there is the GitHub-side convention for a single-line title, not a value `LI_PLUS_PROJECT_LANGUAGE` resolves, so a title stays ASCII English in a workspace whose project language is something else. Parameterizing the title lines while the body lines are read as contract references is the misreading this states against.
 Docs update must be in same PR as implementation. Split docs PR is prohibited.
 docs/ is source of truth. Wiki is mirror, not source. `docs/` in this line = the repository's numbered requirements specs and lettered reference docs. It is not the `docs-tier` of `skills/evolution-persistence-tiering`, which is a persistence rank that spans the wiki as well; same word, different axis.

--- a/rules/operations/operations.md
+++ b/rules/operations/operations.md
@@ -57,10 +57,12 @@ Parent issue with sub-issues = single parent PR. Per-sub-issue PR is prohibited.
 Per-commit CI visibility uses draft PR opened early on the parent branch, not split PRs.
 Commit title = ASCII English only, single line.
 Commit body is not optional.
-Commit body must contain: change summary + intent or background + issue number.
+Commit body must contain: change summary + intent or background + issue reference.
 Commit body must contain at least one sentence in `LI_PLUS_PROJECT_LANGUAGE`.
 PR title = ASCII English only, single line.
 PR body = `LI_PLUS_PROJECT_LANGUAGE`.
+PR body must contain an issue reference.
+Issue reference form = `#<issue number>`. The `#` prefix is part of the form: `issue <number>` or a bare `<number>` is not an issue reference. Applies to the commit body and PR body lines above.
 The two title lines sit on an axis separate from the body lines: ASCII English there is the GitHub-side convention for a single-line title, not a value `LI_PLUS_PROJECT_LANGUAGE` resolves, so a title stays ASCII English in a workspace whose project language is something else. Parameterizing the title lines while the body lines are read as contract references is the misreading this states against.
 Docs update must be in same PR as implementation. Split docs PR is prohibited.
 docs/ is source of truth. Wiki is mirror, not source. `docs/` in this line = the repository's numbered requirements specs and lettered reference docs. It is not the `docs-tier` of `skills/evolution-persistence-tiering`, which is a persistence rank that spans the wiki as well; same word, different axis.


### PR DESCRIPTION
Closes #1728

規則の literal と CI の検査がずれていた点を、規則側を検査に合わせる形で閉じた。CI (`.github/workflows/liplus-ci.yml`) は無変更。

## 変更

`rules/operations/operations.md` Operations Rules:

- `Commit body must contain: ... + issue number.` → `... + issue reference.`
- `PR body must contain an issue reference.` を新規追加（規則側に存在しなかった要求）
- Issue reference form 行を新規追加。`#` 前置が形式の一部であること、`issue <番号>` や裸の番号が issue 参照ではないことを述べ、適用先を commit body 行と PR body 行の両方と名指しする

docs ミラー:

- `docs/4.-Operations.md` ルール節 — 上記3点に対応
- `docs/3.-Task.md` 言語レイヤー分離節 — `ボディ：... + issue 番号` が同じ規範内容の parity copy だったため同時に更新（`operations-on-docs-ownership` の grep sweep で検出）

形式は1行に集約し、commit body 行と PR body 行の双方から参照する形にした。両方の行に形式を書くと写しが二重になり、片方が drift する。

## 設計判断

- 適用範囲は全コミット。CI の Validate Commit Message は `github.event.head_commit.message` しか読まないため要求は検査の届く範囲より広いが、その非対称は規則本文に書いていない。適用の瞬間に消費されるのは要求される形であって検査の射程ではなく、届かない範囲を本文に書けば違反の許可証として読まれる（issue の決定どおり）
- 規則本文に issue 番号・日付・経緯を書いていない（`rules/model/subtractive-structural-beauty.md` の criterion resident, provenance in git）。形式サンプルもプレースホルダ形にしてあり、live reference と読める実番号は入れていない

## 同一 step 内の同種ずれ — 監査結果

issue が「実装時に見ること」とした未確認軸を全て確認した。本 PR で閉じたのは PR body の issue 参照 1 件。body の言語軸は brake 1 を受けて drift として成立と判定し直し、#1731 へ切り出した。

| 軸 | CI の検査 | 規則側 | 判定 |
|---|---|---|---|
| commit body の issue 参照 | `#[0-9]+` | `issue number` としか書いていない | **ずれ。本 PR で修正** |
| PR body の issue 参照 | `#[0-9]+` | 要求が存在しない | **ずれ。本 PR で追加** |
| commit title / PR title の ASCII | 非 ASCII を reject | `ASCII English only, single line` | 規則側が同等以上に厳しい。修正不要 |
| body の言語 | 日本語をハードコード | `LI_PLUS_PROJECT_LANGUAGE` | **drift として成立。本 PR では無変更、#1731 へ切り出し**。当初ここに書いた「本リポジトリでは同じ値に解決する」という理由は誤りで、`docs/D.-Installation.md:216` はこのパラメータを配布先 workspace 専用と宣言し本体の日本語運用と分離している。brake 1 の 3/3 finding を受けて理由を訂正した。畳み込まないのは修理が別物だから（規則に日本語を直書きすれば配布先で誤り／CI 側を触れば brake 1 対象かつ #1728 の決定は CI 無変更／要求自体は `Workspace_Language_Contract` に既在し、欠けているのは Operations Rules からの到達性）。裁定コメント Axis 4 に全長 |
| Validate Issue step | issue title = ASCII / issue body = 日本語 | `skills/operations-on-issue-format/SKILL.md` が Title = ASCII English only / Body = `LI_PLUS_PROJECT_LANGUAGE` を既に持つ。issue に `#N` 要求は CI 側にも無い | ずれなし |

`.github/workflows/liplus-ci.yml` は触っていないため brake 1 の governed surface 判定は workflow 由来では発火しない。ただし `rules/**` の変更を含むため self-evolution PR として brake 1 の対象である。L1 (`layer: L1-model`) は触っていないので brake 2 は非該当。

## 検証

- `python3 -m unittest discover -s tests` → 56 tests OK
- 変更前後の grep sweep 実施。`issue number` / `issue 番号` の残存ヒットは全て別軸（issue 存在の要求、sub-issue link の内部 ID、Decision-Structure の記録）であり、本 PR の対象集合に残りは無い
- `workspace/` は gitignore 済みの wiki sync クローンのため対象外（wiki 同期はリリース時フロー）

## リリース種別

patch。規則文言の整合であり、Li+ ユーザーの surface から観測できる変更ではない。
