### PR TITLE
fix(skills): repoint CI loop safety ref to model-loop-safety skill [skills]

### DIFF
--- a/skills/operations-on-ci/SKILL.md
+++ b/skills/operations-on-ci/SKILL.md
@@ -27,7 +27,7 @@ step3 = conclusion judgment:
   CI pass = all conclusion in [success, skipped, neutral]
 CI pass -> proceed to [PR Review].
 CI fail -> fix and recommit (restart CI loop from step1).
-CI loop safety (ref: Li+core.md#Loop Safety task/debug threshold):
+CI loop safety (ref: `skills/model-loop-safety/SKILL.md` task/debug threshold):
 If still failing = externalize to issue comment, escalate to human.
 
 </ci-loop>


### PR DESCRIPTION
## 目的

`skills/operations-on-ci/SKILL.md:30` の CI loop safety 参照が、リポジトリのツリーに存在しない `Li+core.md` を指していた。指示面に載る死んだポインタであり、読者が辿った瞬間に何も無い状態だったため、現在の所在へ差し替える。

## 変更

`skills/operations-on-ci/SKILL.md:30`

```
- CI loop safety (ref: Li+core.md#Loop Safety task/debug threshold):
+ CI loop safety (ref: `skills/model-loop-safety/SKILL.md` task/debug threshold):
```

## 確認したこと

- issue の制約どおり、差し替え先が実際に閾値を保持していることを確認した。`skills/model-loop-safety/SKILL.md` Invariant に `task / debug = same approach three times -> STOP AND SWITCH` がある。閾値の所在そのものが問題になるケースではなく、ポインタの差し替えで足りる。
- 参照形式は既存の他ファイル（`skills/model-accepted-tradeoff/SKILL.md`、`skills/model-agentic-search/SKILL.md`）と同じ backtick パス表記に揃えた。

## 触らなかったもの

- `docs/G.-Sheepdog-Engineering.md:291` / `:294` の `Li+core.md` 2 件。これは human が本来望んだ monolithic 設計の呼称としての記述であり、読者が辿るポインタではない。記述として現状を誤らせないため、issue の制約どおり変更していない。
- `docs/4.-Operations.md` の CI ループ節。「ループ安全閾値（3回）」と直接書いており死んだ参照を持たないため、追記も不要（subtraction default）。

## release type

patch（指示本文のポインタ修正であり、user/system から観測できる振る舞いの変化を伴わない）

Closes #1748
