### PR TITLE
spec(adapter,rules,skills): strip path, version and scope-escaped provenance [adapter, rules, skills]

### DIFF
--- a/adapter/claude/CLAUDE.md
+++ b/adapter/claude/CLAUDE.md
@@ -150,7 +150,7 @@ Subagent_Delegation:
   Use worktree to isolate.
 
   Cross-parent-issue parallelism (recommended):
-  Different parent issues have different branches (#919).
+  Different parent issues have different branches.
   Create one worktree per parent branch.
   Each subagent works in its own worktree with full commit independence.
 

--- a/adapter/codex/AGENTS.md
+++ b/adapter/codex/AGENTS.md
@@ -38,7 +38,7 @@ Rules are always-on, injected by the `on-session-start` SessionStart hook (Codex
 
 Hook trust (Codex-specific): the SessionStart / UserPromptSubmit / PostToolUse hooks require a one-time GUI trust (Codex App → Settings → Hooks → this project → trust) before they run, and re-trust whenever a Li+ build changes a hook body. Until trusted, rules injection and the per-turn gate re-arm silently do nothing (and no `LI_PLUS_UPDATE_STATUS` marker appears). If you notice the marker and the injected rules are absent at session start, surface the trust requirement to Master.
 
-Skills auto-invoke by description match from `.agents/skills/<name>/SKILL.md` (repo or user scope) — verified native behavior with NO trust gate (#1502). Codex selects a skill by matching the task against its `description` (progressive disclosure: name / description / path first, full `SKILL.md` on selection — same model as the Claude host). No adapter-side trigger table is maintained; detect when a skill's trigger applies and invoke it. The legacy manual trigger table is retired (see Responsibilities below).
+Skills auto-invoke by description match from `.agents/skills/<name>/SKILL.md` (repo or user scope) — verified native behavior with NO trust gate. Codex selects a skill by matching the task against its `description` (progressive disclosure: name / description / path first, full `SKILL.md` on selection — same model as the Claude host). No adapter-side trigger table is maintained; detect when a skill's trigger applies and invoke it.
 
 Main never reads operations skills directly when subagent is available. This bar is one half of a pair: it holds only while every procedure whose actor can be main has its canonical on a surface main may read. `rules/operations/main-agent-procedures.md` states the pair and holds those procedures.
 
@@ -74,7 +74,7 @@ Responsibilities
 
 Rules are re-injected by the SessionStart hook on resume / clear / compact; apply them on any session continuation. Skills auto-invoke by description — no manual re-read table.
 
-Skill auto-invocation routing source = each `skills/<name>/SKILL.md` `description` field. Codex evaluates skill descriptions semantically and invokes the matching skill when its trigger applies. No adapter-side trigger table is maintained (the legacy `on_*` table is retired — #1502 verified native description-invocation from `.agents/skills`). When subagent-absent and a skill is relevant, invoke the skill directly.
+Skill auto-invocation routing source = each `skills/<name>/SKILL.md` `description` field. Codex evaluates skill descriptions semantically and invokes the matching skill when its trigger applies. No adapter-side trigger table is maintained. When subagent-absent and a skill is relevant, invoke the skill directly.
 
 Cold-start Synthesis: the `on-session-start` hook emits the `rules/evolution/cold-start-synthesis.md` literal plus diff-only orientation material at session start. Perform the synthesis through Character_Instance using the emitted material (silent-skip the report when no unique insight remains after synthesis, per the cold-start rule's non-redundancy gate).
 
@@ -170,7 +170,7 @@ Subagent_Delegation:
   Use worktree to isolate.
 
   Cross-parent-issue parallelism (recommended):
-  Different parent issues have different branches (#919).
+  Different parent issues have different branches.
   Create one worktree per parent branch.
   Each subagent works in its own worktree with full commit independence.
 

--- a/rules/evolution/cold-start-synthesis.md
+++ b/rules/evolution/cold-start-synthesis.md
@@ -18,7 +18,7 @@ Steps 1-2 are internal AI priming. They run every session regardless of what the
 Step 3 is conditional output gating, not unconditional report.
 
 Hook coordination:
-`on-session-start.sh` persists and surfaces at session open: decision structure index head, rules/ tree (fetch address table for cold-start-loaded rules cache), recent release tags, open in-progress issues, self-evaluation log head, promotion candidates, cold-start rule literal. Since build-2026-05-11 the hook emits material in diff-only mode (matcher = startup): only sections whose body changed since the previous startup invocation are re-emitted. The cold-start rule literal is always re-anchored regardless of diff state.
+`on-session-start.sh` persists and surfaces at session open: decision structure index head, rules/ tree (fetch address table for cold-start-loaded rules cache), recent release tags, open in-progress issues, self-evaluation log head, promotion candidates, cold-start rule literal. The hook emits material in diff-only mode (matcher = startup): only sections whose body changed since the previous startup invocation are re-emitted. The cold-start rule literal is always re-anchored regardless of diff state.
 
 Hook emission states (matcher = startup):
 - full emit = first session after install, fail-safe (state missing / unreadable / sha256 unavailable / node unavailable), or every section changed. All sections shown. The four reasons are the bash port's set. The PowerShell port parses JSON natively so it has no node dependency, and it calls SHA256 unconditionally with no availability guard, so neither of those two reasons can fire there: its fail-safe set is the two state-file reasons alone.

--- a/skills/model-loop-safety/SKILL.md
+++ b/skills/model-loop-safety/SKILL.md
@@ -13,7 +13,7 @@ layer: L1-model
 ## Position
 
 Layer = L1 Model Layer
-Internal failsafe against same-axis repetition. Not a rule imposed on human — self-regulation for AI behavior. Applies to conversation, task, debug, any repeated attempt. Includes the forbidden loop-type list (persuasion / emotional / over-optimization / justification) absorbed from former `rules/model/prohibited-loops.md`.
+Internal failsafe against same-axis repetition. Not a rule imposed on human — self-regulation for AI behavior. Applies to conversation, task, debug, any repeated attempt. Includes the forbidden loop-type list (persuasion / emotional / over-optimization / justification).
 Requires = `rules/model/rule-policy.md` (on failure or trust damage = re-align, do not accelerate)
 
 </position>


### PR DESCRIPTION
Closes #1752

番号走査が捕まえない 3 経路の来歴を instruction 面から除去した。規律（`rules/model/subtractive-structural-beauty.md` Criterion resident, provenance in git）の literal は変更していない。適用漏れの回収である。

## 変更内容

| 対象 | 経路 | 型 | 操作 |
|---|---|---|---|
| `skills/model-loop-safety/SKILL.md` | パス形 | (c) | `absorbed from former ...` span を除去。現在の状態（forbidden loop-type list を含む）は残る。存在しない `rules/model/prohibited-loops.md` への死んだポインタも同時に解消 |
| `rules/evolution/cold-start-synthesis.md` | バージョン形 | (a) | `Since build-2026-05-11` を除去。diff-only mode の規則として文が立つ |
| `adapter/claude/CLAUDE.md` / `adapter/codex/AGENTS.md` | 走査範囲外 | (a) | parent branch 行の番号を除去。両 port 同形 |
| `adapter/codex/AGENTS.md` L41 | 走査範囲外 | (a) + (b) | NO trust gate 行の番号を除去。直前文が現在の状態を既に述べている legacy trigger table retired 文は文ごと削除 |
| `adapter/codex/AGENTS.md` L77 | 走査範囲外 | (c) | 括弧内の来歴を除去。`No adapter-side trigger table is maintained.` が残る |

## rider 確認

- rider 1（span 単位）: いずれも来歴を運ぶ span 全体を単位として除去。文の一部だけを抜いた断片は残していない
- rider 2（後続参照）: 削除した `see Responsibilities below` の参照先は L77 で、そちらも現在の状態のみを述べる形に整えた。`trigger table` を全域 grep し、宙に浮いた参照が無いことを確認済み

## docs ミラー

変更なし。`docs/` は規律の除外リストにある「来歴を意図して保持する retrieval 面」であり、対応箇所（`docs/2.-Evolution.md` の build 日付、`docs/6.-Adapter.md` / `docs/4.-Operations.md` の番号、`docs/1.-Model.md` の Source 行）はいずれも過去の構成を記述する文脈として正しい。behavior semantic の変更も無いため追随すべき差分が存在しない。

## 検証

- `rules/` / `skills/` / `adapter/` の全域 grep で、残る番号露出は issue 本文が射程外として名指しした箇所（`adapter/*/agents/dialogue-evaluator.*` の source-of-truth ポインタ、`adapter/codex/agents/l1-gate-eval.toml` のコメント行、`adapter/codex/hooks-config.md` の bootstrap 専用仕様）のみ
- バージョン形（`build-20xx`）およびパス形（`absorbed from` / `formerly` / `previously` 等）の追加走査でも、instruction 面に残余なし
- `tests/` に本変更が触れる literal への依存は無い

## release type

patch（instruction 本文からの来歴除去のみ。規則の behavior semantic は不変で、user/system から観測できる振る舞いの変化を伴わない）

## brake 注記

`skills/model-loop-safety/SKILL.md` は `layer: L1-model` を持つため、本 PR は brake 2 の対象。
