### PR TITLE
spec(adapter): strip provenance from hook-emitted session context [adapter]

### DIFF
--- a/adapter/claude/hooks/post-tool-use.sh
+++ b/adapter/claude/hooks/post-tool-use.sh
@@ -49,7 +49,7 @@ esac
 # mentions the command. The message is therefore worded conditionally; asserting
 # that refs were dropped would be false whenever the command merely named it.
 if ! command -v node >/dev/null 2>&1; then
-  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"post-tool-use.sh: `node` not found on PATH, so this hook cannot run. If a PR was just created, its sub-issue `Closes #NNN` refs were not auto-appended — add them manually. See adapter/claude/hooks/post-tool-use.sh (#1540)."}}'
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"post-tool-use.sh: `node` not found on PATH, so this hook cannot run. If a PR was just created, its sub-issue `Closes #NNN` refs were not auto-appended — add them manually. See adapter/claude/hooks/post-tool-use.sh."}}'
   exit 0
 fi
 

--- a/adapter/codex/hooks/post-tool-use.sh
+++ b/adapter/codex/hooks/post-tool-use.sh
@@ -47,7 +47,7 @@ esac
 # node absence must stay observable. A static JSON literal is used because
 # building it would otherwise require the very interpreter that is missing.
 if ! command -v node >/dev/null 2>&1; then
-  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"post-tool-use.sh: `node` not found on PATH, so this hook cannot run. If a PR was just created, its sub-issue `Closes #NNN` refs were not auto-appended — add them manually. See adapter/codex/hooks/post-tool-use.sh (#1632)."}}'
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"post-tool-use.sh: `node` not found on PATH, so this hook cannot run. If a PR was just created, its sub-issue `Closes #NNN` refs were not auto-appended — add them manually. See adapter/codex/hooks/post-tool-use.sh."}}'
   exit 0
 fi
 


### PR DESCRIPTION
## 概要

来歴除去の規律（`rules/model/subtractive-structural-beauty.md` Criterion resident, provenance in git）の scope 内に残っていた第 4 の経路の残余 2 箇所を回収する。規律そのものの改定ではなく、適用漏れの回収。

## 変更内容

いずれも node 不在分岐が `printf` する JSON literal の `additionalContext` 値の末尾。

- `adapter/claude/hooks/post-tool-use.sh:52` — `(#1540)` を除去
- `adapter/codex/hooks/post-tool-use.sh:50` — `(#1632)` を除去

規律は「hook がセッションに注入する文字列」を明示的に scope 内へ置いており、同一ファイル内のコメント行とは扱いが逆になる面である。読者はその文字列が注入された瞬間にそこへ立つため。

## 除去テスト

型 (a)（番号は既に立っている文への装飾）。番号を外しても `See adapter/<host>/hooks/post-tool-use.sh.` が残り、どこを見ればよいかを述べる文として成立するため、文はそのまま残し番号のみを落とした。落ちる単位は span であり、断片は残していない。

## 触っていないもの（理由とセット）

- コメント行 — 規律の除外リスト「hook script comments (`.sh` / `.ps1`)」に該当。適用の瞬間に誰も立っていない。同一ファイル内で境界の両側に触れると除外側まで巻き込むため、意図的に分離した
- 同一注入文字列内の `` `Closes #NNN` `` — placeholder 形であり「Not deletion, where the number sits in a format sample」に該当
- `docs/` ミラー — 来歴を意図して保持する retrieval 面であり追随させない
- `adapter/codex/hooks/post-tool-use.ps1` — node 不在分岐を持たず、対応する注入文字列が存在しない。両 port を揃える対象が無いため、ここでの非対称は欠陥ではない

## 検証

- 両ファイルとも `bash -n` 通過
- node 不在環境を再現して当該分岐を実行し、出力が JSON として parse 可能であることを確認
- 注入文字列内のバッククォート・em dash・`Closes #NNN` が壊れていないことを確認
- hook の分岐条件・出力構造・behavior semantic はいずれも不変

## release type

patch（注入文字列からの来歴除去のみ。user/system observable な影響なし）

Closes #1756
