### PR TITLE
spec(operations): relocate main-actor operations canonicals to the resident rules surface [rules, skills, docs]

### DIFF
--- a/docs/3.-Task.md
+++ b/docs/3.-Task.md
@@ -7,7 +7,7 @@
 
 各セクション冒頭に対応する実体ファイル（rules または skill）を literal reference として明示する。customizer は参照行を見て該当ファイルを直接開けるようにする。
 
-層境界注記：issue 操作詳細（Issue Format / Issue Maturity / Sub-issue Rules）は L4 Operations Layer の skill として実体定義される。本レイヤーからは cross-reference として参照する。
+層境界注記：issue 操作詳細（Issue Format / Issue Maturity / Sub-issue Rules）の実体は L4 Operations Layer に置かれる。本レイヤーからは cross-reference として参照する。L4 内の配置は実行主体で分かれ、Issue Format は親が実行主体であるため `rules/operations/main-agent-procedures.md` 常駐、Issue Maturity / Sub-issue Rules は skill である。
 
 ---
 
@@ -131,7 +131,7 @@ state-machine subset = `in-progress` / `review-pending` / `waiting` / `blocked`�
 
 ## issue 操作
 
-層境界注記：issue 操作（Issue Format、Issue Maturity、Sub-issue Rules）の実体は L4 Operations Layer に配置される個別 skill である。L3 からは、タスク管理の観点で要求される振る舞いを cross-reference として記述する。
+層境界注記：issue 操作（Issue Format、Issue Maturity、Sub-issue Rules）の実体は L4 Operations Layer に配置される。L3 からは、タスク管理の観点で要求される振る舞いを cross-reference として記述する。L4 内では実行主体で配置が分かれる —— 実行主体が親になりうるものは `rules/operations/main-agent-procedures.md` の常駐面、それ以外は個別 skill（`rules/operations/main-agent-procedures.md` の The bar and its pair）。Issue Format は前者、Issue Maturity / Sub-issue Rules は後者である。
 
 - Issue Format の実体 → `rules/operations/main-agent-procedures.md` の `## Issue format`（L4。rules/ 常時ロード。skill 側はポインタ）
 - Issue Maturity の実体 → `skills/operations-on-issue-maturity/SKILL.md`

--- a/docs/3.-Task.md
+++ b/docs/3.-Task.md
@@ -29,7 +29,7 @@ issue に実装を書かない。
 
 ### 責務
 
-issue 運用ルール（`rules/task/task.md` の [Working with Issues]）は rules/ 経由で常時ロードされ、関連する skill（`skills/operations-on-issue-format/SKILL.md` 等、L4 定義）が auto-invocation で詳細な操作手順を補う。
+issue 運用ルール（`rules/task/task.md` の [Working with Issues]）は rules/ 経由で常時ロードされ、関連する skill（`skills/operations-on-issue-maturity/SKILL.md` 等、L4 定義）が auto-invocation で詳細な操作手順を補う。実行主体がメインエージェントになりうる手続きは skill ではなく `rules/operations/main-agent-procedures.md` に正本を置く（Issue Format はこちら）。
 
 issue は AI の内部 TODO である。ユーザーからの指示を待たずに管理する。
 
@@ -133,7 +133,7 @@ state-machine subset = `in-progress` / `review-pending` / `waiting` / `blocked`�
 
 層境界注記：issue 操作（Issue Format、Issue Maturity、Sub-issue Rules）の実体は L4 Operations Layer に配置される個別 skill である。L3 からは、タスク管理の観点で要求される振る舞いを cross-reference として記述する。
 
-- Issue Format の実体 → `skills/operations-on-issue-format/SKILL.md`
+- Issue Format の実体 → `rules/operations/main-agent-procedures.md` の `## Issue format`（L4。rules/ 常時ロード。skill 側はポインタ）
 - Issue Maturity の実体 → `skills/operations-on-issue-maturity/SKILL.md`
 - Sub-issue Rules の実体 → `skills/operations-on-sub-issue/SKILL.md`
 
@@ -141,7 +141,7 @@ state-machine subset = `in-progress` / `review-pending` / `waiting` / `blocked`�
 
 ### Issue Format
 
-（→ `skills/operations-on-issue-format/SKILL.md`。L4。トリガー時ロード）
+（→ `rules/operations/main-agent-procedures.md` の `## Issue format`。L4。rules/ 常時ロード）
 
 #### ルール
 
@@ -207,7 +207,7 @@ spec body が forming 段階に達した時点で、前提セクションに未�
 
 検証完了の判定基準は外部事実照合結果の有無にのみ適用する。主観的な confident 感は対象外とする。前提が「検証済み」と判定されるのは、docs・spec・ソース・ランタイム確認・既存 issue/PR 記録などの外部根拠を引いた場合のみである。「合っている感じがする」は検証ではない。
 
-memo 成熟度は「未完成で恥ずかしい状態」ではなく valid な resting state である。memo 成熟度の issue を生む起票時 rapid path は Issue Format 側（`skills/operations-on-issue-format/SKILL.md`）が持つ。起票の瞬間に発火する面がそちらだからであり、本節が扱うのは後続の forming/ready への昇格判断である。
+memo 成熟度は「未完成で恥ずかしい状態」ではなく valid な resting state である。memo 成熟度の issue を生む起票時 rapid path は Issue Format 側（`rules/operations/main-agent-procedures.md` の `## Issue format`）が持つ。起票の瞬間に発火する面がそちらだからであり、本節が扱うのは後続の forming/ready への昇格判断である。
 
 ### Sub-issue Rules
 
@@ -249,7 +249,7 @@ issue 操作セクションは個別 skill（`skills/operations-on-*/SKILL.md`�
 
 | 操作 | 自動起動される skill |
 |------|----------------------------------|
-| 作成・編集 | `skills/operations-on-issue-format` + `skills/operations-on-sub-issue` |
+| 作成・編集 | `skills/operations-on-sub-issue`（Issue Format は `rules/operations/main-agent-procedures.md` 常駐） |
 | 閲覧 | `skills/operations-on-issue-maturity` + `skills/operations-on-sub-issue` |
 | 閉じる | 自動起動なし |
 | 子イシュー追加 | `skills/operations-on-sub-issue` |
@@ -265,7 +265,7 @@ issue 操作セクションは個別 skill（`skills/operations-on-*/SKILL.md`�
 | Subagent Spawn | `skills/task-subagent-spawn/SKILL.md` | L3 | skill トリガー |
 | Subagent State Labels | `skills/task-subagent-state-labels/SKILL.md` | L3 | skill トリガー |
 | PR Review Judgment | `skills/task-pr-review-judgment/SKILL.md` | L3 | skill トリガー |
-| Issue Format | `skills/operations-on-issue-format/SKILL.md` | L4 | skill トリガー |
+| Issue Format | `rules/operations/main-agent-procedures.md` | L4 | rules/ 常時 |
 | Issue Maturity | `skills/operations-on-issue-maturity/SKILL.md` | L4 | skill トリガー |
 | Sub-issue Rules | `skills/operations-on-sub-issue/SKILL.md` | L4 | skill トリガー |
 

--- a/docs/4.-Operations.md
+++ b/docs/4.-Operations.md
@@ -17,7 +17,7 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 | トリガー | 対象セクション | 権威ソース |
 |----------|----------------|------------|
 | act_now | ブランチとラベルフロー | `skills/operations-on-branch/SKILL.md` |
-| on_issue_create | Issue Format | `skills/operations-on-issue-format/SKILL.md` |
+| on_issue_create | Issue Format | `rules/operations/main-agent-procedures.md` の `## Issue format`（起票は `Parent retains` のため常駐面が正本） |
 | on_issue_edit | Issue Format | 同上 |
 | on_issue_view | Issue Maturity | `skills/operations-on-issue-maturity/SKILL.md` |
 | on_issue_sub | Sub-issue Rules | `skills/operations-on-sub-issue/SKILL.md` |
@@ -29,7 +29,7 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 | on_release | 人間確認が必要な操作 / リリース | `skills/operations-on-release/SKILL.md` |
 | on_release_state | release state フラグ（prerelease / latest）の付与・変更・一括正規化 | `skills/operations-on-release-state/SKILL.md` |
 | on_wiki_sync | リリース後の docs → wiki ミラー同期 | `skills/operations-on-wiki-sync/SKILL.md` |
-| on_webhook_intake | フォアグラウンド webhook 取込 | `skills/operations-foreground-webhook-intake/SKILL.md` |
+| on_webhook_intake | フォアグラウンド webhook 取込 | `rules/operations/main-agent-procedures.md` の `## Foreground webhook notification intake`（実行主体がメインのみのため常駐面が正本） |
 | on_long_output | 長 output / 出力途切れ | `skills/operations-chat-output-limit/SKILL.md` |
 | on_discussions_reference | Discussions 経路 | `skills/operations-discussions/SKILL.md` |
 | on_session_boundary | session 境界での引き継ぎ | `skills/operations-handoff-continuity/SKILL.md` |
@@ -99,6 +99,24 @@ L3 タスクレイヤーとの境界：issue Format、Issue Maturity、Sub-issue
 4例目（#1714）は、ルールに先行したのではなく検出サイン自身が捕まえた最初の1件である：承認待ちの確認手順（Review approval check）を「PR レビュー」節の指す常駐面へ移した。#1713 がこのサインを実装している最中に発見され、その PR の射程外に置かれたため、サインは既知の陽性を1件抱えたまま出荷されていた。サインに捕まったことは修復の中身を変えない —— 適用する維持ルールも移設の形も同じである。
 
 修復の分岐は正本側に基準として置いてある：**メインが自分で実行しなければならない要求は正本ごと移し、メインが運ぶだけの要求はポインタを残す。** 後者は literal の実行主体がサブエージェント側にある形であり、正本は skill 側に留まる。
+
+### 正本の移設は半分にすぎない（#1762）
+
+skill は `description` が場面に合致することで起動する。したがって正本が抜けたあとも description がメインの立つ瞬間を名指したままなら、skill はメインを引き込み続ける —— 禁止を破るのはエージェントの選択ではなくファイル自身のトリガーであり、移設は違反を修復したのではなく改名しただけになる。残り半分は、description を **その skill に残る読み手** まで絞ること。残る読み手はサブエージェント、およびサブエージェント不在フォールバック時のメイン（`skills/task-subagent-delegation/SKILL.md` の Autonomy）である。後者はサブエージェントが存在しないときにのみ発火し、それは禁止が適用されない条件そのものなので、そこへ絞った description は禁止に抵触しない。
+
+どちらの読み手も残らない skill は空であり、ポインタとして残さず削除する。ただし読み手以外に1つだけファイルを支えるものがある：**編集できないポインタの解決先であること。** 削除するとポインタが宙に浮くため load-bearing であり、その場合は「起動条件を持たない」と宣言するリダイレクトスタブとして残す。
+
+### 編集できないアダプタリテラル（#1762）
+
+`adapter/claude/CLAUDE.md` / `adapter/codex/AGENTS.md` の `## Optional Webhook Notification Flow` ブロックはバイト単位で凍結されている。`Li+update.md` が、インストール済みファイルから剥がす legacy trailer を**この同じブロックから導出する**ため、ここが drift すると移行前インストールに対する migration が黙って壊れる。禁止を満たすためにアダプタを編集することは、ガバナンス上の欠陥を実働の migration 欠陥と交換する取引になる。
+
+`rules/model/axis-separation.md` は層をまたぐ矛盾を「上位が勝つ」で決着させず境界の修理へ差し戻すので、リダイレクトは `rules/operations/main-agent-procedures.md` 側が持つ。検出サイン：禁止と同じ sentinel 区画の中に、`operations-*` skill を方針の所在として名指すアダプタ行がある。
+
+### 実測3例（#1762）
+
+- `skills/operations-foreground-webhook-intake` —— 実行主体はメインのみ（発火の瞬間がユーザー turn の開始であり、サブエージェントは turn を持たない）。2026-08-16 のセッション冒頭、サブエージェント利用可能な状態でメインが実際に起動した。正本を常駐面へ移し、skill はリダイレクトスタブとして残した（凍結アダプタ行の解決先であるため）。
+- `skills/operations-on-issue-format` —— `skills/task-subagent-delegation/SKILL.md` の Rules が `issue creation` / `issue management` をモード分岐なしで `Parent retains` に置く。正本を常駐面へ移し、skill はポインタとして残した（サブエージェントは実装中の issue body 更新と失敗報告コメントで到達する）。
+- 本 issue の起票そのもの —— 2例目と同一経路。同じ移設で解消される。
 
 ---
 
@@ -862,7 +880,7 @@ scope = `notifications`（classic PAT）
 
 ### フォアグラウンド webhook 取込
 
-(→ `skills/operations-foreground-webhook-intake/SKILL.md`)
+(→ `rules/operations/main-agent-procedures.md` の `## Foreground webhook notification intake`。`skills/operations-foreground-webhook-intake/SKILL.md` はリダイレクトスタブとして残る)
 
 各ユーザー turn の開始時に webhook イベントを検査し、前景関連または特記すべき項目のみ言及する。前景関連性が安価に判定できない場合は保持して沈黙する。別 AI プロセスの起動は本フローでは禁止。
 

--- a/docs/L.-Hop-Count-Instrument.md
+++ b/docs/L.-Hop-Count-Instrument.md
@@ -80,7 +80,8 @@ S2 のみ #1564 実測2 の記録（ツール2 / 文脈内2）と一致しない
 **S3** — anchor: `Webhook intake policy and procedures:`
 - → `skills/operations-foreground-webhook-intake/SKILL.md` `[tool]`
 - → `adapter/claude/hooks-settings.md` `[tool]`
-- 非計数 — `rules/operations/operations.md`（`mark_processed` の義務）: 鎖のどこにも明示ポインタがない。`grep -n "operations\.md"` は `skills/operations-foreground-webhook-intake/SKILL.md` / `adapter/claude/hooks-settings.md` とも0件、アンカー（`:200`）が名指すのは skill のみ。計数規則（:14）により除外。なお `mark_processed` の実務リテラル自体は skill 本体（`:68`）に到達済みで、この参照は追加跳躍を要さない。
+- 非計数 — `rules/operations/operations.md`（`mark_processed` の義務）: 鎖のどこにも明示ポインタがない。`grep -n "operations\.md"` は `skills/operations-foreground-webhook-intake/SKILL.md` / `adapter/claude/hooks-settings.md` とも0件、アンカー（`:200`）が名指すのは skill のみ。計数規則（:14）により除外。なお `mark_processed` の実務リテラル自体は baseline 時点の skill 本体（`:68`）に到達済みで、この参照は追加跳躍を要さない。
+- 追記（#1762）—— baseline 以降、この鎖の到達先は `rules/operations/main-agent-procedures.md` の `## Foreground webhook notification intake` へ移り、skill 側はリダイレクトスタブになった。上の跳躍数は baseline タグ時点の実測なので書き換えない。
 
 **S4** — anchor: `Sub-issue work exceeding parent body literal ... requires dialogue confirm`
 - → `skills/operations-on-sub-issue/SKILL.md` scope-exceed dialogue confirm `[tool]`

--- a/rules/operations/main-agent-procedures.md
+++ b/rules/operations/main-agent-procedures.md
@@ -36,7 +36,54 @@ Detection sign: a procedure written into an `operations-*` skill whose actor is 
 
 One shape resolves the other way: where the literal's actor is the subagent and the main agent is only the carrier, the canonical stays in the skill and the main agent carries a pointer to it instead (`skills/task-subagent-prompt/SKILL.md` Resume-phase authority boundary). Move the canonical when the main agent has to execute it; leave a pointer when the main agent only has to convey it.
 
+Relocating the canonical is half the move. A skill is invoked by its `description` matching the situation at hand, so a skill whose canonical has left but whose description still names a moment the main agent stands in keeps putting the main agent into the skill — the bar is then broken by the file's own trigger, not by any agent's choice, and the relocation has renamed the violation rather than repaired it. The second half: narrow the description to the reader the skill retains. Retained readers are the subagent, and the main agent under the substrate-absence fallback (`skills/task-subagent-delegation/SKILL.md` Autonomy) — that fallback fires only when no subagent is available, which is the condition under which the bar does not apply, so a description scoped to it does not fire against the bar. A skill that retains neither reader is empty and is deleted, not left as a pointer; `rules/model/subtractive-structural-beauty.md` Core principle (A) already refuses it its place. One thing other than a reader can hold such a file up: being the resolution target of a pointer that cannot itself be edited. That is load-bearing — deleting the file would leave the pointer dangling — so the file stays, as a redirect stub whose description declares it non-invocable rather than naming any moment at all.
+
+Adapter literals that point the main agent at an operations skill are repaired the same way where they are editable. Where one is not — `adapter/claude/CLAUDE.md` and `adapter/codex/AGENTS.md` `## Optional Webhook Notification Flow` is byte-frozen, because `Li+update.md` derives the legacy trailer it strips from installed files out of that very block and drift there silently breaks the migration for pre-migration installs — the redirect is carried here instead. Editing the adapter to satisfy the bar would trade a governance defect for a live migration defect; `rules/model/axis-separation.md` sends a cross-layer contradiction back to the boundary rather than resolving it by precedence, and this file is the boundary the main agent already loads. Detection sign that this shape is present: an adapter line naming an operations skill as where policy lives, in the same sentinel section as the bar.
+
 </the-bar-and-its-pair>
+
+<issue-format>
+
+## Issue format
+
+Canonical. `skills/operations-on-issue-format/SKILL.md` holds the pointer.
+Actor = the parent, unconditionally: `skills/task-subagent-delegation/SKILL.md` Rules puts `issue creation` and `issue management` on `Parent retains` with no mode branch. The subagent reaches this text too — it updates the issue body when premise or constraints change during implementation, and writes the failure-report comment — but it is not the actor the placement is decided on. One canonical on a main-readable surface covers both.
+
+Issue title language:
+Title = ASCII English only.
+Body  = LI_PLUS_PROJECT_LANGUAGE.
+Consistent with the commit title/body language convention (`rules/operations/operations.md` Operations Rules) and PR title convention.
+
+Issue may start from memo. Three fields are convergence target, not creation gate.
+Use only necessary headings. Do not force empty sections.
+Canonical convergence for implementation issue:
+  purpose
+  premise
+  constraints
+  target files (recommended at ready stage)
+Target files = list of files expected to change, with dependency notes (e.g. source⇔docs).
+Target files are optional during memo/forming. Recommended once issue reaches ready.
+Rewrite issue body whenever accepted understanding changes.
+Issue completion is managed through issue state plus PR/CI/release flow, not a dedicated issue-body field.
+
+Checklist = human judgment required (real device test, operational verification).
+Use checklist only when AI cannot judge.
+
+Memo-mode rapid intake (interrupt-minimal path):
+Triggered by human signaling "黙って" / "silent" / "quick memo" / equivalent intent: minimize the cognitive cost of issue creation while the human's main task continues.
+
+- title = ASCII English, bug/kind prefix only (e.g. `bug(rerank): cross-encoder not firing`). No deep verb structure.
+- body = observation fact (1-3 lines) + reproduction hint (1-2 lines). No purpose / premise / constraints / target files.
+- labels = one type label (bug / enhancement / spec / docs / tips) + maturity = `memo`.
+- assignee = unassigned.
+
+Discriminator: "Is this issue creation itself the main task, or is it interrupting the main task?"
+- Interrupting → rapid path.
+- Main task → full forming/ready intake.
+
+Treating "黙って" as "still do full intake but skip discussing it" defeats the interrupt-cost reduction the human asked for. Memo maturity is a valid resting state, not "incomplete and embarrassing"; promotion to forming/ready happens later when the issue itself is the focus (`skills/operations-on-issue-maturity/SKILL.md`).
+
+</issue-format>
 
 <self-review-formal-record>
 
@@ -115,5 +162,75 @@ Post-merge observation for L1 source changes:
 After merging any PR touching L1 Model Layer source (any file with `layer: L1-model` frontmatter, typically `rules/model/*`), apply `rules/operations/operations.md` Post-L1-Merge Runtime Observation. Separate observable axis from Real device test above (AI internal judgment behavior vs external process output).
 
 </merge-execution>
+
+<foreground-webhook-notification-intake>
+
+## Foreground webhook notification intake
+
+Canonical. `skills/operations-foreground-webhook-intake/SKILL.md` holds the pointer.
+Actor = the main agent, and only the main agent: the firing moment is the start of a user turn, and a subagent has none. Residency is therefore not a convenience here — a pull surface cannot reach an actor whose trigger is the turn boundary itself, which is the shape that was observed firing against the bar.
+
+Purpose:
+Keep the active foreground thread lightweight.
+Do not search GitHub broadly for "maybe new comment" when a delivered event source already exists.
+
+Use only in hosts that can run a local command before replying.
+
+source priority:
+  1 = mcp__github-webhook-mcp
+  2 = local webhook store via bundled helper
+  3 = none
+
+delivery mode interaction (LI_PLUS_WEBHOOK_DELIVERY):
+  poll (default) = each user turn, the AI calls mcp__github-webhook-mcp__get_pending_status.
+  channel        = MCP channel pushes events; AI does not poll, intake reads the channel surface.
+  mcp_hook       = the type=mcp_tool UserPromptSubmit hook entry shipped in the
+                   default settings.json template invokes
+                   mcp__github-webhook-mcp__get_pending_status directly at hook
+                   time and injects the result into prompt context. The AI does
+                   not issue the call itself; foreground handling reads the
+                   injected status as if it had been polled.
+                   Preconditions:
+                   - github-webhook-mcp >= v0.11.3 (earlier versions return
+                     generic JSON that Claude Code silently discards because it
+                     does not match a hook decision schema; v0.11.3 wraps the
+                     result in UserPromptSubmit decision shape on the local
+                     bridge side).
+                   - github-webhook-mcp registered as an MCP server in the host
+                     (CLI: .mcp.json / ~/.claude.json / claude mcp add;
+                     Desktop: claude_desktop_config.json). When unregistered,
+                     the mcp_tool resolver returns plain `not connected` text
+                     per turn — harmless but visible noise.
+  source priority above is unchanged across modes; only the *who initiates the
+  call* axis differs. Relevance judgment and destructive consume rules apply
+  identically.
+
+local webhook store:
+  precondition = LI_PLUS_MODE=clone
+  helper path = {workspace_root}/liplus-language/scripts/check_webhook_notifications.py
+  state dir resolution:
+    a = LI_PLUS_WEBHOOK_STATE_DIR from Li+config.md (absolute or workspace_root-relative)
+    b = {workspace_root}/github-webhook-mcp
+    c = {workspace_root}/../github-webhook-mcp
+  if helper missing or state dir unresolved = skip silently
+  helper output = inspect summary with foreground-matched items, notable items, and cleanup candidates
+  helper default = inspect only; preserve unmatched backlog
+  destructive actions = explicit `read` / `done` / `claim` / `cleanup-safe-success` calls only
+
+foreground handling:
+  each user turn start = inspect once before main reply
+  mention only = foreground-matched items or exceptional notable items
+  if relevance cannot be judged cheaply = preserve and stay silent
+  full payload = open only when deeper inspection is needed
+  separate AI process launch = prohibited for this flow
+
+own-operation arrival confirmation:
+  webhook notifications include results of own operations (push, PR, issue, release).
+  these serve as arrival confirmation = proof that the operation reached GitHub.
+  mark_processed own-operation events promptly during foreground check or after the triggering operation.
+  do not accumulate own-operation events for bulk clearing later.
+  external events (other users, bots) = preserve for foreground reporting or explicit handling.
+
+</foreground-webhook-notification-intake>
 
 </main-agent-procedures>

--- a/rules/operations/operations.md
+++ b/rules/operations/operations.md
@@ -32,8 +32,8 @@ Reads through:
 
   [TRIGGER_INDEX]
   act_now      -> Branch And Label Flow
-  on_issue_create -> Issue Format
-  on_issue_edit   -> Issue Format
+  on_issue_create -> Issue format (`rules/operations/main-agent-procedures.md`)
+  on_issue_edit   -> Issue format (`rules/operations/main-agent-procedures.md`)
   on_issue_view   -> Issue Maturity
   on_issue_sub    -> Sub-issue Rules
   on_commit    -> Commit And Push

--- a/skills/operations-foreground-webhook-intake/SKILL.md
+++ b/skills/operations-foreground-webhook-intake/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operations-foreground-webhook-intake
-description: Invoke when the turn carries a github-webhook-mcp channel event or an injected pending-webhook status / the turn carries the per-turn hook reminder to check pending notifications by running get_pending_status silently / the request asks whether anything arrived from GitHub, or names webhook events, pending events or mark_processed. Inspects pending webhook events via MCP or the local helper and reports foreground-relevant or notable items only.
+description: Do not invoke. Redirect stub with no invoke condition - the foreground webhook intake canonical lives in `rules/operations/main-agent-procedures.md` Foreground webhook notification intake, which loads without invocation. The actor is the main agent at a user-turn boundary, and `adapter/claude/CLAUDE.md` / `adapter/codex/AGENTS.md` bar the main agent from `skills/operations-*/SKILL.md`, so this file names no moment. It exists because the adapter `## Optional Webhook Notification Flow` block that points here is byte-frozen by the `Li+update.md` legacy-trailer migration and its pointer must resolve.
 layer: L4-operations
 ---
 
@@ -8,65 +8,10 @@ layer: L4-operations
 
 # Foreground Webhook Notification Intake
 
-Purpose:
-Keep the active foreground thread lightweight.
-Do not search GitHub broadly for "maybe new comment" when a delivered event source already exists.
+Redirect stub. Canonical = `rules/operations/main-agent-procedures.md` Foreground webhook notification intake: purpose, source priority, the `LI_PLUS_WEBHOOK_DELIVERY` mode interaction, the local webhook store resolution, foreground handling, and own-operation arrival confirmation all live there.
 
-Use only in hosts that can run a local command before replying.
+Why nothing is held here: the firing moment is the start of a user turn, which only the main agent has, and the bar keeps the main agent out of this surface. A pull surface cannot reach an actor whose trigger is the turn boundary itself — that mismatch is what was observed firing against the bar, and residency is the repair.
 
-source priority:
-  1 = mcp__github-webhook-mcp
-  2 = local webhook store via bundled helper
-  3 = none
-
-delivery mode interaction (LI_PLUS_WEBHOOK_DELIVERY):
-  poll (default) = each user turn, the AI calls mcp__github-webhook-mcp__get_pending_status.
-  channel        = MCP channel pushes events; AI does not poll, intake reads the channel surface.
-  mcp_hook       = the type=mcp_tool UserPromptSubmit hook entry shipped in the
-                   default settings.json template invokes
-                   mcp__github-webhook-mcp__get_pending_status directly at hook
-                   time and injects the result into prompt context. The AI does
-                   not issue the call itself; foreground handling reads the
-                   injected status as if it had been polled.
-                   Preconditions:
-                   - github-webhook-mcp >= v0.11.3 (earlier versions return
-                     generic JSON that Claude Code silently discards because it
-                     does not match a hook decision schema; v0.11.3 wraps the
-                     result in UserPromptSubmit decision shape on the local
-                     bridge side).
-                   - github-webhook-mcp registered as an MCP server in the host
-                     (CLI: .mcp.json / ~/.claude.json / claude mcp add;
-                     Desktop: claude_desktop_config.json). When unregistered,
-                     the mcp_tool resolver returns plain `not connected` text
-                     per turn — harmless but visible noise.
-  source priority above is unchanged across modes; only the *who initiates the
-  call* axis differs. Relevance judgment and destructive consume rules apply
-  identically.
-
-local webhook store:
-  precondition = LI_PLUS_MODE=clone
-  helper path = {workspace_root}/liplus-language/scripts/check_webhook_notifications.py
-  state dir resolution:
-    a = LI_PLUS_WEBHOOK_STATE_DIR from Li+config.md (absolute or workspace_root-relative)
-    b = {workspace_root}/github-webhook-mcp
-    c = {workspace_root}/../github-webhook-mcp
-  if helper missing or state dir unresolved = skip silently
-  helper output = inspect summary with foreground-matched items, notable items, and cleanup candidates
-  helper default = inspect only; preserve unmatched backlog
-  destructive actions = explicit `read` / `done` / `claim` / `cleanup-safe-success` calls only
-
-foreground handling:
-  each user turn start = inspect once before main reply
-  mention only = foreground-matched items or exceptional notable items
-  if relevance cannot be judged cheaply = preserve and stay silent
-  full payload = open only when deeper inspection is needed
-  separate AI process launch = prohibited for this flow
-
-own-operation arrival confirmation:
-  webhook notifications include results of own operations (push, PR, issue, release).
-  these serve as arrival confirmation = proof that the operation reached GitHub.
-  mark_processed own-operation events promptly during foreground check or after the triggering operation.
-  do not accumulate own-operation events for bulk clearing later.
-  external events (other users, bots) = preserve for foreground reporting or explicit handling.
+Why the file is not deleted: `adapter/claude/CLAUDE.md` and `adapter/codex/AGENTS.md` `## Optional Webhook Notification Flow` names this path, and that block is byte-frozen — `Li+update.md` derives the legacy trailer it strips from installed files out of that very block, so drift there breaks the migration for pre-migration installs. The pointer must resolve; this stub is what it resolves to. See `rules/operations/main-agent-procedures.md` The bar and its pair.
 
 </foreground-webhook-notification-intake>

--- a/skills/operations-on-issue-format/SKILL.md
+++ b/skills/operations-on-issue-format/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operations-on-issue-format
-description: Invoke when the request asks to file, open or write up an issue / the request reports a bug, spec gap or observation that should survive the session as a work unit / the request asks to rewrite or update an issue body / the request asks for a quick silent memo while the human's main task continues. Defines title and body language, the canonical convergence fields (purpose, premise, constraints, target files), the rewrite-on-change rule, and the memo-mode rapid intake path.
+description: Invoke when a delegated subagent is about to update an issue body because premise or constraints changed during implementation / a delegated subagent is about to write a failure-report issue comment / subagent capability is unavailable and the parent is executing operations directly. Pointer only - the Issue Format canonical lives in `rules/operations/main-agent-procedures.md` Issue format. Issue creation and issue management are `Parent retains`, so the moments where the actor is the parent are not invoke conditions here; the canonical reaches that actor by residency instead.
 layer: L4-operations
 ---
 
@@ -8,44 +8,10 @@ layer: L4-operations
 
 # Issue Format
 
-Issue title language:
-Title = ASCII English only.
-Body  = LI_PLUS_PROJECT_LANGUAGE.
-Consistent with the commit title/body language convention (`rules/operations/operations.md` Operations Rules) and PR title convention.
+Pointer. Canonical = `rules/operations/main-agent-procedures.md` Issue format: title and body language, the convergence fields, the rewrite-on-change rule, the checklist bound, and the memo-mode rapid intake path all live there.
 
-Issue may start from memo. Three fields are convergence target, not creation gate.
-Use only necessary headings. Do not force empty sections.
-Canonical convergence for implementation issue:
-  purpose
-  premise
-  constraints
-  target files (recommended at ready stage)
-Target files = list of files expected to change, with dependency notes (e.g. source⇔docs).
-Target files are optional during memo/forming. Recommended once issue reaches ready.
-Rewrite issue body whenever accepted understanding changes.
-Issue completion is managed through issue state plus PR/CI/release flow, not a dedicated issue-body field.
+Why the canonical is not here: `skills/task-subagent-delegation/SKILL.md` Rules puts `issue creation` and `issue management` on `Parent retains` with no mode branch, and `adapter/claude/CLAUDE.md` / `adapter/codex/AGENTS.md` bar the main agent from `skills/operations-*/SKILL.md` while a subagent is available. A canonical held here would sit where its actor cannot read it. `rules/operations/main-agent-procedures.md` The bar and its pair states the placement rule; do not restate the canonical here, the second copy is what drifts.
 
-Checklist = human judgment required (real device test, operational verification).
-Use checklist only when AI cannot judge.
-
-<memo-mode-rapid-intake-interrupt-minimal-path>
-
-## Memo-mode rapid intake (interrupt-minimal path)
-
-Triggered by human signaling "黙って" / "silent" / "quick memo" / equivalent intent: minimize the cognitive cost of issue creation while the human's main task continues.
-
-Rapid path:
-- title = ASCII English, bug/kind prefix only (e.g. `bug(rerank): cross-encoder not firing`). No deep verb structure.
-- body = observation fact (1-3 lines) + reproduction hint (1-2 lines). No purpose / premise / constraints / target files.
-- labels = one type label (bug / enhancement / spec / docs / tips) + maturity = `memo`.
-- assignee = unassigned.
-
-Discriminator: "Is this issue creation itself the main task, or is it interrupting the main task?"
-- Interrupting → rapid path (this section).
-- Main task → full forming/ready intake.
-
-Treating "黙って" as "still do full intake but skip discussing it" defeats the interrupt-cost reduction the human asked for. Memo maturity is a valid resting state, not "incomplete and embarrassing"; promotion to forming/ready happens later when the issue itself is the focus (`skills/operations-on-issue-maturity/SKILL.md`).
-
-</memo-mode-rapid-intake-interrupt-minimal-path>
+The subagent still reaches the canonical — `rules/**` loads for it without invocation — so nothing it needs at issue-body update or failure-report time is lost by the move.
 
 </issue-format>

--- a/skills/operations-on-issue-maturity/SKILL.md
+++ b/skills/operations-on-issue-maturity/SKILL.md
@@ -27,6 +27,6 @@ Subjective confidence is outside this criterion.
 A premise is verified only when external evidence (docs, spec, source, runtime probe, existing issue/PR record) is cited.
 "feels correct" is not verification.
 
-Memo maturity is a valid resting state, not "incomplete and embarrassing". The creation-time rapid path that produces a memo-maturity issue lives at `skills/operations-on-issue-format/SKILL.md` Memo-mode rapid intake, which fires at issue creation; promotion to forming/ready is judged here, later, when the issue itself is the focus.
+Memo maturity is a valid resting state, not "incomplete and embarrassing". The creation-time rapid path that produces a memo-maturity issue lives at `rules/operations/main-agent-procedures.md` Issue format, which fires at issue creation; promotion to forming/ready is judged here, later, when the issue itself is the focus.
 
 </issue-maturity>


### PR DESCRIPTION
Closes #1762

## 目的

`Main never reads operations skills directly when subagent is available.` という bar と、実行主体（actor）が main agent である `operations-*` skill の共存を解消する。

## 実装

### 正本の移設（`rules/operations/main-agent-procedures.md`）

| 移設元 | 移設先 | 実行主体 |
|---|---|---|
| `skills/operations-on-issue-format/SKILL.md` | `## Issue format` | 親（`Parent retains: issue creation / issue management`、モード分岐なし） |
| `skills/operations-foreground-webhook-intake/SKILL.md` | `## Foreground webhook notification intake` | main のみ（発火の瞬間がユーザー turn の開始。サブエージェントは turn を持たない） |

### The bar and its pair への追記

既存の維持ルールは「正本を移して skill にポインタを残す」までしか書いていない。実測3例はその先で漏れていたので、欠けていた2形を明文化した。

1. **正本の移設は半分にすぎない。** skill は `description` が場面に合致することで起動する。正本が抜けたあとも description がメインの立つ瞬間を名指したままなら、skill はメインを引き込み続ける —— 禁止を破るのはエージェントの選択ではなくファイル自身のトリガーであり、移設は違反を改名しただけになる。残り半分は description を **残る読み手**（サブエージェント / サブエージェント不在フォールバック時のメイン）まで絞ること。どちらの読み手も残らない skill は削除する。ただし **編集できないポインタの解決先** であることは読み手以外に唯一ファイルを支える理由になり、その場合はリダイレクトスタブとして残す。

2. **編集できないアダプタリテラルの扱い。** 下記の通り。

### skill 側

- `skills/operations-on-issue-format/SKILL.md` = ポインタ化。サブエージェント側の読み手（実装中の issue body 更新 / 失敗報告コメント）が残るため削除しない。
- `skills/operations-foreground-webhook-intake/SKILL.md` = リダイレクトスタブ化。起動条件を持たないことを description で宣言する。

## アダプタを編集しなかった理由

対象ファイルに `adapter/claude/CLAUDE.md` / `adapter/codex/AGENTS.md` が挙がっていたが、`## Optional Webhook Notification Flow` ブロックは **バイト単位で凍結** されている。

`Li+update.md`（:160-171 / :313-324）が、インストール済みファイルから剥がす legacy trailer を **この同じブロックから導出** する。`tests/test_adapter_update_contract.py` の `KNOWN_LEGACY_BODIES` がそのバイト一致を固定しており、ここを書き換えると移行前インストールに対する migration が黙って壊れる。

禁止を満たすためにアダプタを編集することは、ガバナンス上の欠陥を実働の migration 欠陥と交換する取引になる。`rules/model/axis-separation.md` は層をまたぐ矛盾を precedence で決着させず境界の修理へ差し戻すので、リダイレクトを L4 の常駐面（`rules/operations/main-agent-procedures.md`）に置いた。メインはこの面を常時ロードしているため、凍結行を経由せずに正本へ到達する。

この判断と、それを裏づける検出サインは正本側にも記述してある。

## 検知構造を入れなかった理由

issue が「検知構造の導入までを本 issue のスコープに含めるかは実装時判断」としていた点について、**入れなかった**。

調査中に、実行主体が main になりうる `operations-*` skill が本 issue の3例より広く存在する可能性を観測した（`operations-on-release` / `operations-on-release-state` / `operations-on-sub-issue` / `operations-on-issue-maturity` / `operations-chat-output-limit` など、いずれも親が保持する責務に対応する）。この状態で機械的な検知構造を入れると、本 issue の対象ファイル外の skill 群で CI が落ちる。検知構造の導入は、対象範囲の確定を先に要する別 issue が適切と判断した。

## 変更ファイル

- `rules/operations/main-agent-procedures.md` — 正本2節の新設 + The bar and its pair 追記
- `rules/operations/operations.md` — `[TRIGGER_INDEX]` の `on_issue_create` / `on_issue_edit` 追随
- `skills/operations-on-issue-format/SKILL.md` — ポインタ化
- `skills/operations-foreground-webhook-intake/SKILL.md` — リダイレクトスタブ化
- `skills/operations-on-issue-maturity/SKILL.md` — memo rapid path のポインタ追随
- `docs/3.-Task.md` / `docs/4.-Operations.md` — 配置対応表・トリガー表・The bar and its pair 節の追随
- `docs/L.-Hop-Count-Instrument.md` — S3 に追記（baseline 跳躍数は書き換えない）

## 影響スコープ

Li+ 内部のガバナンス構造のみ。user / system 観測可能な挙動変化なし → `rules/operations/release-version-rule.md` により **patch**。L1 Model Layer source には触れていない（brake 2 非該当）。

## 検証

`python -m unittest discover -s tests` = 56 tests OK
